### PR TITLE
Fix : CSS 수정

### DIFF
--- a/src/components/ChatRoom/ChatRoomCard.tsx
+++ b/src/components/ChatRoom/ChatRoomCard.tsx
@@ -133,14 +133,14 @@ export default function ChatRoomCard({
 
   return (
     <div className="w-[45%] h-full">
-      <div className="flex flex-col h-full bg-chatRoomPurple rounded-lg overflow-scroll scroll-box">
+      <div className="flex flex-col h-full bg-chatRoomPurple rounded-lg scroll-box">
         <div
-          className="w-full h-[10%] bg-indigo-600 text-white flex justify-start items-center pl-8"
+          className="w-full py-[4%] bg-indigo-600 text-white flex justify-start items-center pl-8"
           id="chat-input-header"
         >
           <h2 className="text-2xl font-bold font-main">{chatRoomData.name}</h2>
         </div>
-        <div id="message-content-box" className="grow p-4">
+        <div id="message-content-box" className="grow p-4 overflow-scroll scroll-box">
           {comments.map((comment) => (
             <div key={comment.id}>
               <div className="flex items-center mb-2">
@@ -172,7 +172,7 @@ export default function ChatRoomCard({
         <form
           onSubmit={handleCommentSubmit}
           id="message-input-area"
-          className="h-[10%] bg-indigo-600 flex items-center px-[5%]"
+          className="h-[10%] bg-indigo-600 flex items-center px-[5%] py-[3%]"
         >
           <div className="w-full flex justify-between gap-x-2 items-center">
             <input

--- a/src/components/ChatRoom/PlaceCard.tsx
+++ b/src/components/ChatRoom/PlaceCard.tsx
@@ -6,8 +6,8 @@ interface PlaceCardProps {
 
 export default function PlaceCard({ chatRoomData }: PlaceCardProps) {
   return (
-    <div className="w-[45%] flex flex-col gap-y-2">
-      <div id="placeImage" className="h-[560px] overflow-hidden">
+    <div className="w-[45%] flex flex-col gap-y-3">
+      <div id="placeImage" className="h-[580px] overflow-hidden">
         <div className="w-full h-full">
           <img
             src={chatRoomData.imageUrl}
@@ -17,7 +17,7 @@ export default function PlaceCard({ chatRoomData }: PlaceCardProps) {
         </div>
       </div>
 
-      <div id="placeDescription" className="h-[300px] bg-white rounded-lg">
+      <div id="placeDescription" className="h-[330px] bg-white rounded-lg">
         <h2 className="text-2xl font-bold p-6 font-main">
           {chatRoomData.name}
         </h2>


### PR DESCRIPTION
상세 페이지로 이동했을 때, 채팅이 많은 경우(ex. 가거도 소흑산도) 채팅방 박스의 장소 이름과 채팅 입력 div가 줄어드는 현상 해결

1. 기존의 채팅방 박스 자체 div에 있던 overflow-scroll scroll-box 속성을 채팅 목록 div로 옮겨서 채팅이 많은 경우에 채팅 목록만 스크롤 되도록 했습니다.
2. 채팅방 박스의 장소 이름과 채팅 입력 div에 py 값을 줘서 크기가 고정되어 있도록 했습니다. (혹시 이 부분에서도 padding을 쓰면 안된다면 다른 방법을 찾아보겠습니다)