### PR TITLE
select bar 관련 작업

### DIFF
--- a/src/components/ChatRoom/ChatRoomCard.tsx
+++ b/src/components/ChatRoom/ChatRoomCard.tsx
@@ -30,7 +30,7 @@ export default function ChatRoomCard({
     });
 
     sock.onopen = async () => {
-      console.log('connection opened!');
+      // console.log('connection opened!');
       setFrontSocket(sock);
     };
 
@@ -76,7 +76,7 @@ export default function ChatRoomCard({
     };
 
     sock.onclose = () => {
-      console.log('disconnected!');
+      // console.log('disconnected!');
       setFrontSocket(null);
     };
 
@@ -140,7 +140,10 @@ export default function ChatRoomCard({
         >
           <h2 className="text-2xl font-bold font-main">{chatRoomData.name}</h2>
         </div>
-        <div id="message-content-box" className="grow p-4 overflow-scroll scroll-box">
+        <div
+          id="message-content-box"
+          className="grow p-4 overflow-scroll scroll-box"
+        >
           {comments.map((comment) => (
             <div key={comment.id}>
               <div className="flex items-center mb-2">

--- a/src/components/Main/MainEightRegionList.tsx
+++ b/src/components/Main/MainEightRegionList.tsx
@@ -14,7 +14,6 @@ export default function MainEightRegionList() {
 
       const data = await response.json();
 
-      console.log(data);
       const processedData = data.map((item: MainEightRegion) => {
         return {
           id: item.id,

--- a/src/components/Main/MainRecommendedPlaceList.tsx
+++ b/src/components/Main/MainRecommendedPlaceList.tsx
@@ -19,7 +19,5 @@ export default function MainRecommendedPlaceList() {
     getData();
   }, []);
 
-  console.log(recommendedPlaces);
-
   return <MainRecommendedPlaceListComponent places={recommendedPlaces} />;
 }

--- a/src/components/SelectPlace/SelectPlacePlaceListComponent.tsx
+++ b/src/components/SelectPlace/SelectPlacePlaceListComponent.tsx
@@ -13,8 +13,6 @@ export default function SelectPlacePlaceListComponent({
     (state) => state.selectPlace.selectedMainArea
   );
 
-  console.log(selectedMainAreaId);
-
   const handleSavePlace = (placeId: number) => {
     if (savedPlaces.includes(placeId)) {
       setSavedPlaces(savedPlaces.filter((id) => id !== placeId));

--- a/src/components/SelectPlace/SelectPlaceSigunguFilter.tsx
+++ b/src/components/SelectPlace/SelectPlaceSigunguFilter.tsx
@@ -1,16 +1,21 @@
 // 아무 권역도 선택되지 않았다면 일단 가장 인기 있는 10개의 도시를 꼽아줄 수도 있어야 함
-import { useAppSelector } from '@context/store';
+import { useAppSelector, useAppDispatch } from '@context/store';
+import { changeSigungu } from '@context/slices/select-place-slice';
 import { useState, useEffect } from 'react';
-import { MainEightRegion } from '@_types/type';
+import { MainEightRegion, sigunGuInfo } from '@_types/type';
 
 export default function SelectPlaceSigunguFilter() {
-  const [allSigunGuList, setAllSigunGuList] = useState<string[][]>([]);
-  const [showingSigunguList, setShowingSigunguList] = useState<string[]>([]);
+  const [allSigunGuList, setAllSigunGuList] = useState<sigunGuInfo[][]>([]);
+  const [showingSigunguList, setShowingSigunguList] = useState<sigunGuInfo[]>(
+    []
+  );
 
   // mainAreaId는 1 ~ 8로, 서울 ~ 제주에 대응
   const selectedMainAreaId = useAppSelector(
     (state) => state.selectPlace.selectedMainArea
   );
+
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     async function getTourMajorRegion() {
@@ -21,7 +26,7 @@ export default function SelectPlaceSigunguFilter() {
       const majorRigiondata = await response.json();
 
       const sigunGuList = majorRigiondata.map((regionData: MainEightRegion) => {
-        return regionData.sigungu?.map((data) => data.name);
+        return regionData.sigungu;
       });
 
       setAllSigunGuList(sigunGuList);
@@ -32,20 +37,32 @@ export default function SelectPlaceSigunguFilter() {
 
   useEffect(() => {
     if (selectedMainAreaId !== null) {
+      console.log('yes!');
+      console.log(allSigunGuList);
       setShowingSigunguList(allSigunGuList[selectedMainAreaId - 1]);
     }
   }, [selectedMainAreaId]);
 
+  if (showingSigunguList === undefined) {
+    return null;
+  }
+
   return (
     <div className="flex text-black items-center justify-evenly bg-white-800 h-[85px] min-h-[85px]">
-      {showingSigunguList.map((city) => (
-        <div
-          key={city}
-          className=" hover: cursor-pointer hover:text-chatRoomPurple hover:text-white active:text-white w-24 bg-gray-200 text-center rounded-3xl font-main text-lg"
-        >
-          {city}
-        </div>
-      ))}
+      {selectedMainAreaId !== null &&
+        showingSigunguList.map((city) => (
+          <div
+            key={city.name}
+            className=" hover: cursor-pointer hover:text-chatRoomPurple hover:text-white active:text-white w-24 bg-gray-200 text-center rounded-3xl font-main text-lg"
+            onClick={() =>
+              dispatch(
+                changeSigungu({ areaId: city.areaId, sigunguId: city.id })
+              )
+            }
+          >
+            {city.name}
+          </div>
+        ))}
     </div>
   );
 }

--- a/src/components/SelectPlace/SelectPlaceSigunguFilter.tsx
+++ b/src/components/SelectPlace/SelectPlaceSigunguFilter.tsx
@@ -1,23 +1,44 @@
 // 아무 권역도 선택되지 않았다면 일단 가장 인기 있는 10개의 도시를 꼽아줄 수도 있어야 함
+import { useAppSelector } from '@context/store';
+import { useState, useEffect } from 'react';
+import { MainEightRegion } from '@_types/type';
 
 export default function SelectPlaceSigunguFilter() {
-  const cities = [
-    '포항',
-    '경주',
-    '구미',
-    '경산',
-    '안동',
-    '영천',
-    '김천',
-    '문경',
-    '울진',
-    '영덕',
-    '울릉도',
-  ];
+  const [allSigunGuList, setAllSigunGuList] = useState<string[][]>([]);
+  const [showingSigunguList, setShowingSigunguList] = useState<string[]>([]);
+
+  // mainAreaId는 1 ~ 8로, 서울 ~ 제주에 대응
+  const selectedMainAreaId = useAppSelector(
+    (state) => state.selectPlace.selectedMainArea
+  );
+
+  useEffect(() => {
+    async function getTourMajorRegion() {
+      const response = await fetch(
+        `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/major-region`
+      );
+
+      const majorRigiondata = await response.json();
+
+      const sigunGuList = majorRigiondata.map((regionData: MainEightRegion) => {
+        return regionData.sigungu?.map((data) => data.name);
+      });
+
+      setAllSigunGuList(sigunGuList);
+    }
+
+    getTourMajorRegion();
+  }, []);
+
+  useEffect(() => {
+    if (selectedMainAreaId !== null) {
+      setShowingSigunguList(allSigunGuList[selectedMainAreaId - 1]);
+    }
+  }, [selectedMainAreaId]);
 
   return (
     <div className="flex text-black items-center justify-evenly bg-white-800 h-[85px] min-h-[85px]">
-      {cities.map((city) => (
+      {showingSigunguList.map((city) => (
         <div
           key={city}
           className=" hover: cursor-pointer hover:text-chatRoomPurple hover:text-white active:text-white w-24 bg-gray-200 text-center rounded-3xl font-main text-lg"

--- a/src/types/type.tsx
+++ b/src/types/type.tsx
@@ -9,7 +9,7 @@ export interface MainRecommendPlaceComponentProps {
   places: MainRecommendPlace[];
 }
 
-interface sigunGuInfo {
+export interface sigunGuInfo {
   // 아래의 인터페이스에서 활용하기 위한 것
   id: string;
   areaId: string;

--- a/src/types/type.tsx
+++ b/src/types/type.tsx
@@ -9,10 +9,18 @@ export interface MainRecommendPlaceComponentProps {
   places: MainRecommendPlace[];
 }
 
+interface sigunGuInfo {
+  // 아래의 인터페이스에서 활용하기 위한 것
+  id: string;
+  areaId: string;
+  name: string;
+}
+
 export interface MainEightRegion {
   id: number;
   name: string;
   imageUrl: string;
+  sigungu?: sigunGuInfo[]; // 해당 속성은 선택적임
 }
 
 export interface MainEightRegionComponentProps {

--- a/src/utils/apis.ts
+++ b/src/utils/apis.ts
@@ -1,0 +1,9 @@
+export async function getTourMajorRegion() {
+  const response = await fetch(
+    `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/major-region`
+  );
+
+  const data = await response.json();
+
+  return data;
+}


### PR DESCRIPTION
현재 select-place 페이지에서 권역 바 작업한 내용이 있어 PR 날립니다.

1. 일단 사용자가 권역조차 선택하지 않고 해당 페이지에 들어온 경우, 시군구 필터바는 보이지 않도록 했어요. 그런데 해당 시군구 필터 컴포넌트를 아예 `return null` 해버리면 `SelectPlacePlaceList` 컴포넌트가 위로 올라와서 이격이 발생하는 상황이 발생하여 일단 아무것도 보이지 않되, 기본 공간은 차지하고 있도록 만들어줬습니다.
2. 사용자가 `SelectPlaceMainAreaFilter` 필터 컴포넌트에서 권역을 생성하면 그에 해당하는 도시들이 보여지게 시군구 필터에 데이터들을 연결해줬습니다. 관련된 퍼블리싱 작업 찬영님께서 해주실 때 item 간 간격 조절 같은 것은 원하시는 대로 하셔도 될 것 같아요.
3. 장소 목록 페이지에서 특정 권역의 특정 시군구에 속한 장소를 보고 뒤로 가기 버튼을 눌러(**navigate(-1)**) 뒤로 갈 경우에, 기존 필터 설정이 살아 있을 수 있도록 만들어놨습니다(이건 redux로 전역 상태 관리를 해줬어요). 당연한 것이지만 사용자가 ctrl + r 버튼을 누를 때에는 그냥 페이지가 초기화 되기 때문에 이건 상태도 초기화됩니다.

이상입니다. 