### PR TITLE
Feat/travel plan list

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     </script>
   </head>
   <body>
-    <div id="root" class="scroll-box"></div>
+    <div id="root" class="scroll-box flex flex-col"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/SelectPlace/SelectPlacePlaceListComponent.tsx
+++ b/src/components/SelectPlace/SelectPlacePlaceListComponent.tsx
@@ -61,7 +61,7 @@ export default function SelectPlacePlaceListComponent({
   };
 
   return (
-    <div className="bg-dftBackgroundGray flex justify-center">
+    <div className="bg-dftBackgroundGray flex justify-center grow">
       <div className="w-full flex flex-col items-center pt-9 rounded-lg overflow-scroll scroll-box">
         {places.map((place) => (
           <div

--- a/src/components/travel-plans-list/TravelPlansListSection.tsx
+++ b/src/components/travel-plans-list/TravelPlansListSection.tsx
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { travelPlanProp } from '@_types/type';
+
+export default function TravelPlansListSection() {
+  const [travelPlanList, setTravelPlanList] = useState<travelPlanProp[]>([]);
+
+  useEffect(() => {
+    async function getTravelPlanList() {
+      const response = await fetch(
+        `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/plan`
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        setTravelPlanList(data);
+      } else {
+        console.log(response);
+        throw new Error('fetching travel plan list is failed!');
+      }
+    }
+
+    try {
+      getTravelPlanList();
+    } catch (error) {
+      console.log(error);
+    }
+  }, []);
+
+  console.log(travelPlanList);
+  return (
+    <main className="h-travelListSection flex flex-col items-center mt-20">
+      <p className="w-[70%] text-2xl font-main mb-[20px]">
+        여행 계획서 둘러보기
+      </p>
+    </main>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,6 @@
     height: 100dvh;
     margin: 0;
   }
-
   #root {
     height: 100%;
     display: flex;

--- a/src/pages/TravelPlansList.tsx
+++ b/src/pages/TravelPlansList.tsx
@@ -1,3 +1,13 @@
+import Header from '@components/all/Header';
+import Footer from '@components/all/Footer';
+import TravelPlansListSection from '@components/travel-plans-list/TravelPlansListSection';
+
 export default function TravelPlansListPage() {
-  return <div>This is travel plan list page</div>;
+  return (
+    <>
+      <Header />
+      <TravelPlansListSection />
+      <Footer />
+    </>
+  );
 }

--- a/src/types/type.tsx
+++ b/src/types/type.tsx
@@ -79,3 +79,10 @@ export interface SelectPlacePlace {
 export interface SelectPlacePlaceProps {
   places: SelectPlacePlace[];
 }
+
+export interface travelPlanProp {
+  id: number;
+  name: string;
+  startDate: string;
+  endDate: string;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,9 @@ export default {
         bookmarkRed: '#FF8577',
         backgroundLightGray: '#F7F8F9',
       },
+      height: {
+        travelListSection: 'calc(100% - 160px)',
+      },
     },
   },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,9 @@ export default {
       },
       height: {
         travelListSection: 'calc(100% - 160px)',
+        selectPlaceListMainSection: 'cal(100dvh - 330px)',
       },
+      minHeight: {},
     },
   },
 };


### PR DESCRIPTION
1. `http://localhost:5173/travel-plans-list` 페이지에서 기존의 여행계획서 정보를 조회할 수 있도록 api 연결
2. 장소 목록 페이지에서 제주-남제주군/북제주군의 경우 장소가 존재하지 않는데 이때 main section이 줄어드는 문제를 해결
> id=root 컴포넌트를 column 방향의 flex로 설정해놔서 전체 앱에 적용됩니다. 다만, 지금 만들어논 거랑은 충돌 안하는 거 같아서 괜찮다고 판단했습니다. 