### PR TITLE
여행 계획 플랜 모달 기능 1차 완성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react-redux": "^7.1.33",
         "@types/sockjs-client": "^1.5.4",
         "react": "^18.2.0",
+        "react-calendar": "^5.0.0",
         "react-dom": "^18.2.0",
         "react-modal": "^3.16.1",
         "react-redux": "^9.1.1",
@@ -1452,6 +1453,14 @@
         "vite": "^4 || ^5"
       }
     },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -1749,6 +1758,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2333,6 +2350,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2741,6 +2769,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2761,6 +2815,14 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/minimatch": {
@@ -2892,6 +2954,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -3250,6 +3320,30 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.0.0.tgz",
+      "integrity": "sha512-bHcE5e5f+VUKLd4R19BGkcSQLpuwjKBVG0fKz74cwPW5xDfNsReHdDbfd4z3mdjuUuZzVtw4Q920mkwK5/ZOEg==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react-redux": "^7.1.33",
     "@types/sockjs-client": "^1.5.4",
     "react": "^18.2.0",
+    "react-calendar": "^5.0.0",
     "react-dom": "^18.2.0",
     "react-modal": "^3.16.1",
     "react-redux": "^9.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import ChatRoomPage from '@pages/ChatRoom';
 import SignUpPage from '@pages/SignUp';
 import TravelPlanPage from '@pages/TravelPlan';
 import TravelPlansListPage from '@pages/TravelPlansList';
+import Modal from 'react-modal';
 
 function App() {
   return (
@@ -26,5 +27,7 @@ function App() {
     </BrowserRouter>
   );
 }
+
+Modal.setAppElement('#root');
 
 export default App;

--- a/src/components/travel-plans-list/CategoryBar.tsx
+++ b/src/components/travel-plans-list/CategoryBar.tsx
@@ -4,10 +4,10 @@ export default function CategoryBar() {
       id="category-bar"
       className="flex w-[80%] h-10 justify-evenly items-center border-0 border-t-2 border-b-2 border-black mb-5"
     >
-      <p className="w-[20%] text-center">이름</p>
+      <p className="w-[30%] text-center">이름</p>
       <p className="w-[40%] text-center">여행 날짜</p>
-      <p className="w-[20%] text-center">지역</p>
-      <p className="w-[20%] text-center">추가 작업</p>
+
+      <p className="w-[30%] text-center">추가 작업</p>
     </div>
   );
 }

--- a/src/components/travel-plans-list/PlanCreateButton.tsx
+++ b/src/components/travel-plans-list/PlanCreateButton.tsx
@@ -1,13 +1,18 @@
 export default function PlanCreateButton({
   handleIsModalState,
+  handlePlanStepState,
 }: {
   handleIsModalState: (st: boolean) => void;
+  handlePlanStepState: (st: number) => void;
 }) {
   return (
     <div className="w-[80%] h-[60px] absolute bottom-0 mb-10 flex justify-end items-center">
       <button
         className="w-[200px] h-[60px] rounded-lg bg-textPurple text-white text-2xl font-main"
-        onClick={() => handleIsModalState(true)}
+        onClick={() => {
+          handleIsModalState(true);
+          handlePlanStepState(1);
+        }}
       >
         계획 생성하기
       </button>

--- a/src/components/travel-plans-list/TravelPlanItem.tsx
+++ b/src/components/travel-plans-list/TravelPlanItem.tsx
@@ -14,18 +14,17 @@ export default function TravelPlanItem({
         alt="place hat logo"
         width="50px"
         height="45px"
+        className="absolute left-0"
       />
-      <p id="travel-name" className="w-[20%] text-center">
+      <p id="travel-name" className="w-[30%] text-center">
         {name}
       </p>
       <p id="travel-date" className="w-[40%] text-center">
         {`${startDateList[0]}년 ${startDateList[1]}월 ${startDateList[2]}일`}~
         {`${endDateList[0]}년 ${endDateList[1]}월 ${endDateList[2]}일`}
       </p>
-      <p id="travel-region" className="w-[20%] text-center">
-        어딘가
-      </p>
-      <p id="travel-extra-work" className="w-[20%] text-center">
+
+      <p id="travel-extra-work" className="w-[30%] text-center">
         nope
       </p>
     </div>

--- a/src/components/travel-plans-list/TravelPlansListSection.tsx
+++ b/src/components/travel-plans-list/TravelPlansListSection.tsx
@@ -5,10 +5,16 @@ import TravelPlanItem from './TravelPlanItem';
 import PlanCreateButton from './PlanCreateButton';
 import Modal from 'react-modal';
 import ReactModal from 'react-modal';
+import TravelNameInput from './modal-content/TravelNameInput';
+import TravelCalendar from './modal-content/TravelCalendar';
 
 export default function TravelPlansListSection() {
   const [travelPlanList, setTravelPlanList] = useState<travelPlanProp[]>([]);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [planStepState, setPlanStepState] = useState<number>(0); // 0 일때 아직 생성 이전, 1일때 제목, 2일때 날짜
+  const [planName, setPlanName] = useState<string>('');
+  const [startDate, setStartDate] = useState<string>('');
+  const [endDate, setEndDate] = useState<string>('');
 
   useEffect(() => {
     async function getTravelPlanList() {
@@ -43,9 +49,6 @@ export default function TravelPlansListSection() {
       left: '0',
       right: '0',
       bottom: '0',
-      // display: 'flex',
-      // justifyContent: 'center',
-      // alignItems: 'center',
     },
     content: {
       width: '70%',
@@ -59,11 +62,20 @@ export default function TravelPlansListSection() {
       bottom: '15%',
       borderRadius: '15px',
       display: 'flex',
+      justifyContent: 'center',
       alignItems: 'center',
       position: 'relative',
       backgroundColor: '#5551FF',
     },
   };
+
+  function handleCloseModal() {
+    setIsModalOpen(false);
+    setPlanStepState(0);
+    setPlanName('');
+    setStartDate('');
+    setEndDate('');
+  }
 
   return (
     <main className="h-travelListSection flex flex-col items-center mt-20 relative">
@@ -81,15 +93,37 @@ export default function TravelPlansListSection() {
           />
         );
       })}
-      <PlanCreateButton handleIsModalState={setIsModalOpen} />
-      <Modal isOpen={isModalOpen} style={customModalStyles}>
-        {/* <div className="absolute top-5 right-5">x</div> */}
+      <PlanCreateButton
+        handleIsModalState={setIsModalOpen}
+        handlePlanStepState={setPlanStepState}
+      />
+      <Modal
+        isOpen={isModalOpen}
+        style={customModalStyles}
+        onRequestClose={() => handleCloseModal()}
+      >
         <img
           src="/assets/close.svg"
           alt="This is closing UI image"
           className="absolute top-5 right-5 hover:cursor-pointer"
-          onClick={() => setIsModalOpen(false)}
+          onClick={() => handleCloseModal()}
         />
+        {planStepState === 1 && (
+          <TravelNameInput
+            planName={planName}
+            handlePlanName={setPlanName}
+            handlePlanStepState={setPlanStepState}
+          />
+        )}
+        {planStepState === 2 && (
+          <TravelCalendar
+            planName={planName}
+            startDate={startDate}
+            handleStartDate={setStartDate}
+            endDate={endDate}
+            handleEndDate={setEndDate}
+          />
+        )}
       </Modal>
     </main>
   );

--- a/src/components/travel-plans-list/TravelPlansListSection.tsx
+++ b/src/components/travel-plans-list/TravelPlansListSection.tsx
@@ -13,8 +13,8 @@ export default function TravelPlansListSection() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [planStepState, setPlanStepState] = useState<number>(0); // 0 일때 아직 생성 이전, 1일때 제목, 2일때 날짜
   const [planName, setPlanName] = useState<string>('');
-  const [startDate, setStartDate] = useState<string>('');
-  const [endDate, setEndDate] = useState<string>('');
+  // const [startDate, setStartDate] = useState<string>('');
+  // const [endDate, setEndDate] = useState<string>('');
 
   useEffect(() => {
     async function getTravelPlanList() {
@@ -73,8 +73,8 @@ export default function TravelPlansListSection() {
     setIsModalOpen(false);
     setPlanStepState(0);
     setPlanName('');
-    setStartDate('');
-    setEndDate('');
+    // setStartDate('');
+    // setEndDate('');
   }
 
   return (
@@ -115,15 +115,7 @@ export default function TravelPlansListSection() {
             handlePlanStepState={setPlanStepState}
           />
         )}
-        {planStepState === 2 && (
-          <TravelCalendar
-            planName={planName}
-            startDate={startDate}
-            handleStartDate={setStartDate}
-            endDate={endDate}
-            handleEndDate={setEndDate}
-          />
-        )}
+        {planStepState === 2 && <TravelCalendar planName={planName} />}
       </Modal>
     </main>
   );

--- a/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
@@ -1,29 +1,82 @@
 // 캘린더는 시작일, 종료일 상태와 이를 바꾸는 함수를 받고, 백엔드로 보낼 계획명도 전달은 받아야 한다
 import Calendar from 'react-calendar';
-import 'react-calendar/dist/Calendar.css';
+// import 'react-calendar/dist/Calendar.css';
+import { useState } from 'react';
 
-export default function TravelCalendar({
-  planName,
-  startDate,
-  handleStartDate,
-  endDate,
-  handleEndDate,
-}: {
-  planName: string;
-  startDate: string;
-  handleStartDate: (st: string) => void;
-  endDate: string;
-  handleEndDate: (st: string) => void;
-}) {
+interface travelDates {
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
+export default function TravelCalendar({ planName }: { planName: string }) {
+  const [dates, setDates] = useState<travelDates>({
+    startDate: null,
+    endDate: null,
+  });
   console.log(planName);
-  console.log(startDate);
-  console.log(handleStartDate);
-  console.log(endDate);
-  console.log(handleEndDate);
+
+  const onDateChange = (value: Date) => {
+    console.log(typeof value);
+    const { startDate, endDate } = dates;
+
+    if (!startDate || (startDate && endDate)) {
+      // start가 없거나, 둘다 차있으면 새로 고르는걸 start로, 나머지는 null로
+      setDates({ startDate: value, endDate: null });
+    } else if (startDate && !endDate) {
+      const newEndDate = value;
+      const diffInDays =
+        (+newEndDate - +new Date(startDate)) / (1000 * 60 * 60 * 24);
+
+      if (diffInDays < 0) {
+        alert('종료일은 시작일보다 나중이어야 합니다!');
+        return;
+      }
+
+      if (diffInDays > 5) {
+        alert('시작일과 종료일의 차이는 최대 5일이어야 합니다!');
+        return;
+      } else {
+        setDates({ startDate, endDate: newEndDate });
+      }
+    }
+  };
+
+  const tileClassName = ({ date, view }: { date: Date; view: string }) => {
+    const { startDate, endDate } = dates;
+
+    if (view === 'month') {
+      if (startDate && date.getTime() === new Date(startDate).getTime()) {
+        return 'custom-selected';
+      }
+
+      if (endDate && date.getTime() === new Date(endDate).getTime()) {
+        return 'custom-selected';
+      }
+
+      // 사이에 위치한 날들에 대한 스타일링
+      if (
+        startDate &&
+        endDate &&
+        date > new Date(startDate) &&
+        date < new Date(endDate)
+      ) {
+        return 'custom-range';
+      }
+    }
+
+    return null;
+  };
+
+  console.log(dates);
+
   return (
     <div className="w-[80%] h-[80%] bg-white rounded-2xl flex flex-col justify-start items-center pt-[50px] gap-y-3">
       <p className="text-3xl font-main">여행의 날짜를 알려주세요!</p>
-      <Calendar className="react-calendar" />
+      <Calendar
+        className="react-calendar__navigation"
+        onClickDay={onDateChange}
+        tileClassName={tileClassName}
+      />
       <div id="finish-button" className="w-[80%] flex justify-end items-center">
         <button className="w-[150px] h-[45px] rounded-lg text-xl font-main bg-textPurple text-white disabled:cursor-not-allowed disabled:opacity-50">
           완료하기

--- a/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
@@ -1,0 +1,34 @@
+// 캘린더는 시작일, 종료일 상태와 이를 바꾸는 함수를 받고, 백엔드로 보낼 계획명도 전달은 받아야 한다
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+
+export default function TravelCalendar({
+  planName,
+  startDate,
+  handleStartDate,
+  endDate,
+  handleEndDate,
+}: {
+  planName: string;
+  startDate: string;
+  handleStartDate: (st: string) => void;
+  endDate: string;
+  handleEndDate: (st: string) => void;
+}) {
+  console.log(planName);
+  console.log(startDate);
+  console.log(handleStartDate);
+  console.log(endDate);
+  console.log(handleEndDate);
+  return (
+    <div className="w-[80%] h-[80%] bg-white rounded-2xl flex flex-col justify-start items-center pt-[50px] gap-y-3">
+      <p className="text-3xl font-main">여행의 날짜를 알려주세요!</p>
+      <Calendar className="react-calendar" />
+      <div id="finish-button" className="w-[80%] flex justify-end items-center">
+        <button className="w-[150px] h-[45px] rounded-lg text-xl font-main bg-textPurple text-white disabled:cursor-not-allowed disabled:opacity-50">
+          완료하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/travel-plans-list/modal-content/TravelNameInput.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelNameInput.tsx
@@ -1,0 +1,41 @@
+export default function TravelNameInput({
+  planName,
+  handlePlanName,
+  handlePlanStepState,
+}: {
+  planName: string;
+  handlePlanName: (st: string) => void;
+  handlePlanStepState: (st: number) => void;
+}) {
+  return (
+    <div className="w-[80%] h-[80%] bg-white rounded-2xl flex flex-col justify-start items-center pt-[50px] gap-y-28">
+      <p className="text-3xl font-main">여행 계획서의 이름을 알려주세요!</p>
+      <div className="w-[70%] flex items-center gap-x-[30px]">
+        <label htmlFor="planName" className="text-3xl font-main">
+          이름 :
+        </label>
+        <input
+          type="text"
+          placeholder="Enter Your Travel Plan Name"
+          className="grow appearance-none border-b-2 border-textPurple focus:outline-none text-2xl pl-1"
+          value={planName}
+          onChange={(event) => {
+            handlePlanName(event.target.value);
+          }}
+        />
+      </div>
+      <div
+        id="next-step-button"
+        className="w-[80%]  flex justify-end items-center"
+      >
+        <button
+          className="w-[200px] h-[60px] rounded-lg text-xl font-main bg-textPurple text-white disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={() => handlePlanStepState(2)}
+          disabled={planName === ''}
+        >
+          날짜 선택하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,29 @@
 
 @layer components {
   .react-calendar {
-    @apply w-[60%] h-fit border-none;
+    @apply w-[60%] h-fit border-none flex flex-col;
+  }
+  .react-calendar__navigation {
+    @apply w-full flex justify-center items-center p-2;
+  }
+  .react-calendar__navigation > button {
+    flex-grow: 1;
+  }
+  .react-calendar__month-view {
+    @apply h-[];
+  }
+
+  .react-calendar__tile {
+    @apply text-center p-2 hover:bg-gray-200;
+  }
+
+  .custom-selected {
+    background-color: rgb(37 99 235);
+    color: white;
+    border-radius: 0.5rem;
+  }
+  .custom-range {
+    background-color: rgb(191 219 254);
+    color: black;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,9 @@
     display: none;
   }
 }
+
+@layer components {
+  .react-calendar {
+    @apply w-[60%] h-fit border-none;
+  }
+}


### PR DESCRIPTION
현재 다운 받아 보시면 알겠지만, 모달창으로 여행 계획 생성하는 작업을 하고 있습니다.
캘린더를 처음부터 구현하면 좀 피곤해서 `react-calendar`라는 라이브러리를 사용합니다. 아직 세세한 퍼블리싱 조정까지는 다 못해서 계속할 생각입니다.
일단 그것보다 찬영님께서 작성하실 여행 계획 설계 페이지로 넘어가는 흐름이 더 중요한 것 같아요.
1. 제가 일단 여행 계획의 이름, 여행 시작 날짜, 종료 날짜(이건 최대 5일로 설정합니다)는 여행 계획 추가(제가 지금 만든 페이지)의 상태로 관리합니다.
2. 완료하기 버튼을 누르면 그때 바로 백엔드에 계획이름, 시작일, 종료일을 전송하여 해당 계획의 id를 만드려고 했었는데 영태님께 여쭤보니 그건 제 단에서 하는게 아니라 사용자가 처음 계획을 만들고 저장하기 버튼을 눌렀을 때 백엔드로 전송되는 거라고 말씀해주셨습니다.
3. 그러면 제가 만든 페이지에서 찬영님 페이지로 계획이름, 시작일, 종료일이라는 상태를 넘겨야겠죠? 이걸 전역상태 redux로 할겁니다. 제가 만든 페이지에서 추후에 지역 상태를 redux 전역에 담아서 보낼거에요.
4. 그러면 찬영님은 useAppSelector 훅을 이용해서 그 상태를 받아서 작업하시면 됩니다.
5. 이 방식이 아니라 그냥 react 순수 상태로 하려면 너무 불필요하게 state를 app.tsx까지 끌어올려야해요. 근데 이건 코드가 너무 복잡해지고 추후에 디버깅하기에도 너무 불편하다고 생각합니다.
6. 지난번에 제가 jira 였나 첨부해드린 redux 자료 보시면 좋을 것 같습니다. 

혹시나 궁금하신 부분 있다면 말씀해주세요