### PR TITLE
Feat/travel plan list에서의 전역 상태 관리 설정

### DIFF
--- a/src/components/travel-plans-list/TravelPlansListSection.tsx
+++ b/src/components/travel-plans-list/TravelPlansListSection.tsx
@@ -13,8 +13,6 @@ export default function TravelPlansListSection() {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [planStepState, setPlanStepState] = useState<number>(0); // 0 일때 아직 생성 이전, 1일때 제목, 2일때 날짜
   const [planName, setPlanName] = useState<string>('');
-  // const [startDate, setStartDate] = useState<string>('');
-  // const [endDate, setEndDate] = useState<string>('');
 
   useEffect(() => {
     async function getTravelPlanList() {

--- a/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
@@ -2,13 +2,18 @@
 import Calendar from 'react-calendar';
 // import 'react-calendar/dist/Calendar.css';
 import { useState } from 'react';
-
-interface travelDates {
-  startDate: Date | null;
-  endDate: Date | null;
-}
+import { useAppDispatch } from '@context/store';
+import {
+  changePlanName,
+  changeStartDate,
+  changeEndDate,
+} from '@context/slices/travel-plan-slice';
+import { travelDates } from '@_types/type';
+import { useNavigate } from 'react-router-dom';
 
 export default function TravelCalendar({ planName }: { planName: string }) {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const [dates, setDates] = useState<travelDates>({
     startDate: null,
     endDate: null,
@@ -68,6 +73,12 @@ export default function TravelCalendar({ planName }: { planName: string }) {
   };
 
   console.log(dates);
+  function handleClickCompletButton() {
+    dispatch(changePlanName(planName));
+    dispatch(changeStartDate(dates.startDate));
+    dispatch(changeEndDate(dates.endDate));
+    navigate(`/travel-plan/${planName}`);
+  }
 
   return (
     <div className="w-[80%] h-[80%] bg-white rounded-2xl flex flex-col justify-start items-center pt-[50px] gap-y-3">
@@ -78,7 +89,10 @@ export default function TravelCalendar({ planName }: { planName: string }) {
         tileClassName={tileClassName}
       />
       <div id="finish-button" className="w-[80%] flex justify-end items-center">
-        <button className="w-[150px] h-[45px] rounded-lg text-xl font-main bg-textPurple text-white disabled:cursor-not-allowed disabled:opacity-50">
+        <button
+          className="w-[150px] h-[45px] rounded-lg text-xl font-main bg-textPurple text-white disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={handleClickCompletButton}
+        >
           완료하기
         </button>
       </div>

--- a/src/context/slices/travel-plan-slice.ts
+++ b/src/context/slices/travel-plan-slice.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { travelDates } from '@_types/type';
+
+const initialTravelPlanState: travelDates & { name: string | null } = {
+  name: null,
+  startDate: null,
+  endDate: null,
+};
+
+const travelPlanSlice = createSlice({
+  name: 'traelPlan',
+  initialState: initialTravelPlanState,
+  reducers: {
+    changePlanName: (state, action: PayloadAction<string | null>) => {
+      state.name = action.payload;
+    },
+    changeStartDate: (state, action: PayloadAction<Date | null>) => {
+      state.startDate = action.payload;
+    },
+    changeEndDate: (state, action: PayloadAction<Date | null>) => {
+      state.endDate = action.payload;
+    },
+  },
+});
+
+export const { changePlanName, changeStartDate, changeEndDate } =
+  travelPlanSlice.actions;
+
+export default travelPlanSlice.reducer;

--- a/src/context/slices/travel-plan-slice.ts
+++ b/src/context/slices/travel-plan-slice.ts
@@ -8,7 +8,7 @@ const initialTravelPlanState: travelDates & { name: string | null } = {
 };
 
 const travelPlanSlice = createSlice({
-  name: 'traelPlan',
+  name: 'travelPlan',
   initialState: initialTravelPlanState,
   reducers: {
     changePlanName: (state, action: PayloadAction<string | null>) => {

--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import selectPlaceReducer from '@context/slices/select-place-slice';
+import travelPlanReducer from '@context/slices/travel-plan-slice';
 import { TypedUseSelectorHook, useSelector, useDispatch } from 'react-redux';
 
 export const store = configureStore({
   reducer: {
     selectPlace: selectPlaceReducer,
+    travelPlan: travelPlanReducer,
   },
 });
 

--- a/src/pages/TravelPlan.tsx
+++ b/src/pages/TravelPlan.tsx
@@ -1,7 +1,12 @@
-import { useParams } from 'react-router-dom';
+import { useAppSelector } from '@context/store';
 
 export default function TravelPlanPage() {
-  const { travelPlanName } = useParams();
+  const travelPlanName = useAppSelector((state) => state.travelPlan.name);
+  const travelStartDate = useAppSelector((state) => state.travelPlan.startDate);
+  const travelEndDate = useAppSelector((state) => state.travelPlan.endDate);
 
-  return <div>This is travel plan {travelPlanName} page</div>;
+  console.log(travelPlanName);
+  console.log(travelStartDate);
+  console.log(travelEndDate);
+  return <div>This is travel plan page</div>;
 }

--- a/src/types/type.tsx
+++ b/src/types/type.tsx
@@ -86,3 +86,8 @@ export interface travelPlanProp {
   startDate: string;
   endDate: string;
 }
+
+export interface travelDates {
+  startDate: Date | null;
+  endDate: Date | null;
+}


### PR DESCRIPTION
계획 생성 모달에서 계획 이름을 입력하고, 시작 날짜와 종료 날짜(간격 최대 5일)를 정하고 완료하기 버튼을 누르면 계획명, 시작일, 종료일이 전역 상태로서 공유됩니다. 지금 현재 `TravelPlan` 컴포넌트에서 `useAppSelector()` 훅을 통해 받아볼 수 있게 만들어놨습니다.
찬영님께서 기존에 정말 생성된 여행 계획을 조회하는 것과 아직 생성은 되지 않은 첫 생성 페이지를 분리하고 싶다면 관련 코드만 바꾸면 될 것 같아욥