### PR TITLE
Refactor/travel plans list

### DIFF
--- a/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
@@ -1,7 +1,7 @@
 // 캘린더는 시작일, 종료일 상태와 이를 바꾸는 함수를 받고, 백엔드로 보낼 계획명도 전달은 받아야 한다
 import Calendar from 'react-calendar';
 // import 'react-calendar/dist/Calendar.css';
-import { useState } from 'react';
+import { useState, useReducer } from 'react';
 import { useAppDispatch } from '@context/store';
 import {
   changePlanName,
@@ -10,6 +10,7 @@ import {
 } from '@context/slices/travel-plan-slice';
 import { travelDates } from '@_types/type';
 import { useNavigate } from 'react-router-dom';
+import { calendarInitialState } from '@context/calendarInitialState';
 
 export default function TravelCalendar({ planName }: { planName: string }) {
   const dispatch = useAppDispatch();
@@ -18,7 +19,6 @@ export default function TravelCalendar({ planName }: { planName: string }) {
     startDate: null,
     endDate: null,
   });
-  console.log(planName);
 
   const onDateChange = (value: Date) => {
     console.log(typeof value);
@@ -81,12 +81,12 @@ export default function TravelCalendar({ planName }: { planName: string }) {
   }
 
   return (
-    <div className="w-[80%] h-[80%] bg-white rounded-2xl flex flex-col justify-start items-center pt-[50px] gap-y-3">
+    <div className="w-[80%] h-[80%] bg-white rounded-2xl flex flex-col justify-start items-center pt-[56px] gap-y-3">
       <p className="text-3xl font-main">여행의 날짜를 알려주세요!</p>
       <Calendar
         className="react-calendar__navigation"
         onClickDay={onDateChange}
-        tileClassName={tileClassName}
+        // tileClassName={tileClassName}
       />
       <div id="finish-button" className="w-[80%] flex justify-end items-center">
         <button

--- a/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
@@ -1,53 +1,83 @@
 // 캘린더는 시작일, 종료일 상태와 이를 바꾸는 함수를 받고, 백엔드로 보낼 계획명도 전달은 받아야 한다
 import Calendar from 'react-calendar';
 // import 'react-calendar/dist/Calendar.css';
-import { useState, useReducer } from 'react';
+import { useReducer } from 'react';
 import { useAppDispatch } from '@context/store';
 import {
   changePlanName,
   changeStartDate,
   changeEndDate,
 } from '@context/slices/travel-plan-slice';
-import { travelDates } from '@_types/type';
 import { useNavigate } from 'react-router-dom';
-import { calendarInitialState } from '@context/calendarInitialState';
+import {
+  calendarInitialState,
+  calendarReducerFn,
+} from '@context/calendarInitialState';
+import { isEarlierDate } from '@utils/date';
 
 export default function TravelCalendar({ planName }: { planName: string }) {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  const [dates, setDates] = useState<travelDates>({
-    startDate: null,
-    endDate: null,
-  });
+  // const [dates, setDates] = useState<travelDates>({
+  //   startDate: null,
+  //   endDate: null,
+  // });
 
-  const onDateChange = (value: Date) => {
-    console.log(typeof value);
-    const { startDate, endDate } = dates;
+  const [dateState, dateDispatch] = useReducer(
+    calendarReducerFn,
+    calendarInitialState
+  );
 
-    if (!startDate || (startDate && endDate)) {
-      // start가 없거나, 둘다 차있으면 새로 고르는걸 start로, 나머지는 null로
-      setDates({ startDate: value, endDate: null });
-    } else if (startDate && !endDate) {
-      const newEndDate = value;
-      const diffInDays =
-        (+newEndDate - +new Date(startDate)) / (1000 * 60 * 60 * 24);
+  // const onDateChange = (value: Date) => {
+  //   console.log(typeof value);
+  //   const { startDate, endDate } = dates;
 
-      if (diffInDays < 0) {
-        alert('종료일은 시작일보다 나중이어야 합니다!');
-        return;
+  //   if (!startDate || (startDate && endDate)) {
+  //     // start가 없거나, 둘다 차있으면 새로 고르는걸 start로, 나머지는 null로
+  //     setDates({ startDate: value, endDate: null });
+  //   } else if (startDate && !endDate) {
+  //     const newEndDate = value;
+  //     const diffInDays =
+  //       (+newEndDate - +new Date(startDate)) / (1000 * 60 * 60 * 24);
+
+  //     if (diffInDays < 0) {
+  //       alert('종료일은 시작일보다 나중이어야 합니다!');
+  //       return;
+  //     }
+
+  //     if (diffInDays > 5) {
+  //       alert('시작일과 종료일의 차이는 최대 5일이어야 합니다!');
+  //       return;
+  //     } else {
+  //       setDates({ startDate, endDate: newEndDate });
+  //     }
+  //   }
+  // };
+
+  const onDateClick = (incomingDate: Date) => {
+    if (dateState.startDate === null && dateState.endDate === null) {
+      dateDispatch({ type: 'noPreviousData', incomingDate });
+    } else if (dateState.startDate !== null && dateState.endDate === null) {
+      if (isEarlierDate(incomingDate, dateState.startDate) === 1) {
+        dateDispatch({
+          type: 'isPrevStartDayAndNotAfterEndDay',
+          incomingDate,
+        });
+      } else if (isEarlierDate(incomingDate, dateState.startDate) === 3) {
+        dateDispatch({
+          type: 'isPrevStartDayAndAfterEndDay',
+          incomingDate,
+        });
       }
-
-      if (diffInDays > 5) {
-        alert('시작일과 종료일의 차이는 최대 5일이어야 합니다!');
-        return;
-      } else {
-        setDates({ startDate, endDate: newEndDate });
-      }
+    } else {
+      dateDispatch({ type: 'isPrevStartDayAndIsPrevEndDay', incomingDate });
     }
   };
 
+  // console.log(dateState);
+
   const tileClassName = ({ date, view }: { date: Date; view: string }) => {
-    const { startDate, endDate } = dates;
+    const { startDate, endDate } = dateState;
 
     if (view === 'month') {
       if (startDate && date.getTime() === new Date(startDate).getTime()) {
@@ -72,12 +102,11 @@ export default function TravelCalendar({ planName }: { planName: string }) {
     return null;
   };
 
-  console.log(dates);
   function handleClickCompletButton() {
     dispatch(changePlanName(planName));
-    dispatch(changeStartDate(dates.startDate));
-    dispatch(changeEndDate(dates.endDate));
-    navigate(`/travel-plan/${planName}`);
+    dispatch(changeStartDate(dateState.startDate));
+    dispatch(changeEndDate(dateState.endDate));
+    navigate(`/travel-plan-all`);
   }
 
   return (
@@ -85,8 +114,8 @@ export default function TravelCalendar({ planName }: { planName: string }) {
       <p className="text-3xl font-main">여행의 날짜를 알려주세요!</p>
       <Calendar
         className="react-calendar__navigation"
-        onClickDay={onDateChange}
-        // tileClassName={tileClassName}
+        onClickDay={onDateClick}
+        tileClassName={tileClassName}
       />
       <div id="finish-button" className="w-[80%] flex justify-end items-center">
         <button

--- a/src/context/calendarInitialState.ts
+++ b/src/context/calendarInitialState.ts
@@ -6,7 +6,12 @@ export const calendarInitialState: travelDates = {
 };
 
 interface actionType {
-  type: string;
+  type:
+    | 'noPreviousData'
+    | 'isPrevStartDayAndAfterEndDay'
+    | 'isPrevStartDayAndNotAfterEndDay'
+    | 'isPrevStartDayAndIsPrevEndDay'
+    | 'isPrevStartDayAndIsPrevEndDay';
   incomingDate: Date;
 }
 

--- a/src/context/calendarInitialState.ts
+++ b/src/context/calendarInitialState.ts
@@ -1,0 +1,46 @@
+import { travelDates } from '@_types/type';
+
+export const calendarInitialState: travelDates = {
+  startDate: null,
+  endDate: null,
+};
+
+interface actionType {
+  type: string;
+  incomingDate: Date;
+}
+
+// 날짜의 로직을 계산할 리듀서 함수에 해당함
+export function calendarReducerFn(
+  state: travelDates,
+  action: actionType
+): travelDates {
+  if (action.type === 'noPreviousData') {
+    return {
+      startDate: action.incomingDate,
+      endDate: null,
+    };
+  }
+  if (action.type === 'isPrevStartDayAndAfterEndDay') {
+    return {
+      startDate: state?.startDate,
+      endDate: action.incomingDate,
+    };
+  }
+
+  if (action.type === 'isPrevStartDayAndNotAfterEndDay') {
+    return {
+      startDate: action.incomingDate,
+      endDate: null,
+    };
+  }
+
+  if (action.type === 'isPrevStartDayAndIsPrevEndDay') {
+    return {
+      startDate: action.incomingDate,
+      endDate: null,
+    };
+  }
+
+  return { startDate: null, endDate: null };
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,10 @@
+// date 간 누가 더 빠른 날짜인지를 나타내는 함수. 1, 2, 3은 각각 더 빠름, 같음, 더 느림을 의미함
+export const isEarlierDate = (firstDate: Date, secondDate: Date): number => {
+  if (firstDate.getTime() < secondDate.getTime()) {
+    return 1;
+  } else if (firstDate.getTime() === secondDate.getTime()) {
+    return 2;
+  } else {
+    return 3;
+  }
+};


### PR DESCRIPTION
calendar에서 날짜를 선택할 때 기존에는 최대 4박 5일의 일정을 계획할 수 있도록 하고 있었습니다. 하지만 지난 번에 영태님, 준호님과의 회의 이후 이 제약을 풀기로 했습니다.
이를 복잡한 함수로 구현하기보다는, `useReducer()`에 쪼개서 구현했습니다. calendar에 대한 퍼블리싱은 내일 또 진행할 예정입니다. 

타입스크립트의 강력한 효과를 느낄 수 있었습니다. 