### PR TITLE
Feat/135 : /travel-plan-all 페이지에서의 135 티켓 

### DIFF
--- a/src/components/travel-plan-all/PlanListAll.tsx
+++ b/src/components/travel-plan-all/PlanListAll.tsx
@@ -50,6 +50,10 @@ export default function PlanListALL() {
   }, [selectedPlace]);
 
   useEffect(() => {
+    setBookMarkedPlaces(places[selectedDayIndex]);
+  }, [selectedDayIndex]);
+
+  useEffect(() => {
     const loadSavedPlaces = async () => {
       try {
         const data = await fetchSavedPlaces();

--- a/src/components/travel-plan-all/PlanListAll.tsx
+++ b/src/components/travel-plan-all/PlanListAll.tsx
@@ -5,7 +5,9 @@ import PlaceChat from './placeChat';
 import { fetchSavedPlaces, fetchChatRoomData } from '@utils/fetchFunctions';
 
 export default function PlanListALL() {
-  const [selectedPlace, setSelectedPlace] = useState<SelectPlacePlace | null>(null);
+  const [selectedPlace, setSelectedPlace] = useState<SelectPlacePlace | null>(
+    null
+  );
   const [chatRoomData, setChatRoomData] = useState<ChatRoomData | null>(null);
   const [places, setPlaces] = useState<SelectPlacePlace[]>([]);
 
@@ -53,18 +55,18 @@ export default function PlanListALL() {
   };
 
   return (
-    <main className="flex h-[calc(100vh-160px)]"> 
+    <main className="flex h-[calc(100vh-160px)]">
       <div className="flex w-full h-full overflow-y-scroll">
-        <div className="w-1/3 h-full flex-grow-0">
-          <BookmarkedPlaceList 
-            onPlaceClick={handlePlaceClick} 
+        <div id="left-section" className="w-1/3 h-full flex-grow-0">
+          <BookmarkedPlaceList
+            onPlaceClick={handlePlaceClick}
             places={places}
             onMoveUp={(index) => movePlace(index, index - 1)}
             onMoveDown={(index) => movePlace(index, index + 1)}
             onDelete={deletePlace}
           />
         </div>
-        <div className="w-2/3 h-full flex-grow">
+        <div id="right-secton" className="w-2/3 h-full flex-grow">
           {selectedPlace ? (
             <PlaceChat chatRoomData={chatRoomData} place={selectedPlace} />
           ) : (
@@ -75,4 +77,3 @@ export default function PlanListALL() {
     </main>
   );
 }
-

--- a/src/components/travel-plan-all/bookmarkedPlaceList.tsx
+++ b/src/components/travel-plan-all/bookmarkedPlaceList.tsx
@@ -1,67 +1,97 @@
 import { SelectPlacePlace } from '@_types/type';
 
+interface planListAllPlaceItem {
+  id: string;
+  name: string;
+  imageUrl: string;
+}
+
 interface BookmarkedPlaceListProps {
-  onPlaceClick: (placeId: string) => void;
+  totalTravelDay: number;
+  onPlaceClick: (
+    placeId: string,
+    bookMarkedPlaces: planListAllPlaceItem[]
+  ) => void;
   places: SelectPlacePlace[];
   onMoveUp: (index: number) => void;
   onMoveDown: (index: number) => void;
   onDelete: (index: number) => void;
+  handleSelectedDay: (dayIndex: number) => void;
 }
 
 export default function BookmarkedPlaceList({
+  totalTravelDay,
   onPlaceClick,
   places,
   onMoveUp,
   onMoveDown,
   onDelete,
+  handleSelectedDay,
 }: BookmarkedPlaceListProps) {
-
   return (
-    <div className="bg-gray-200 h-full flex justify-center grow pl-12">
-      <div className="bg-white w-[450px] flex flex-col items-center overflow-scroll scroll-box">
-        {places.map((place, index) => (
-          <div
-            key={place.id}
-            className="flex flex-col w-[90%] mb-4 py-6 pl-20 pr-5 rounded-lg bg-white hover:cursor-pointer"
-          >
-            <div className="flex justify-between items-center mb-2">
-              <h2
-                className="text-2xl font-bold font-main"
-                onClick={() => onPlaceClick(place.id)}
-              >
-                {place.name}
-              </h2>
-              <div className="flex space-x-2">
-                <button
-                  onClick={() => onMoveUp(index)}
-                  disabled={index === 0}
-                  className="px-2 py-1 rounded disabled:opacity-50"
-                >
-                  <img src="/assets/UP.svg" alt="위로" className="w-6 h-6" />
-                </button>
-                <button
-                  onClick={() => onMoveDown(index)}
-                  disabled={index === places.length - 1}
-                  className="px-2 py-1 rounded disabled:opacity-50"
-                >
-                  <img src="/assets/DOWN.svg" alt="아래로" className="w-6 h-6" />
-                </button>
-                <button
-                  onClick={() => onDelete(index)}
-                  className="px-2 py-1 rounded"
-                >
-                  <img src="/assets/delete-icon.svg" alt="삭제" className="w-6 h-6" />
-                </button>
-              </div>
+    <div className="bg-gray-200 h-full flex justify-center grow ">
+      <div id="day-selectionarea" className="!w-12">
+        {[...Array(totalTravelDay).keys()]
+          .map((i) => i + 1)
+          .map((dayIndex) => (
+            <div key={dayIndex} onClick={() => handleSelectedDay(dayIndex - 1)}>
+              {dayIndex}일 차
             </div>
-            <img
-              src={place.imageUrl}
-              alt="장소 사진"
-              className="w-80 h-[150px] object-cover my-3.5"
-              onClick={() => onPlaceClick(place.id)}
-            />
-          </div>
-        ))}
+          ))}
+      </div>
+      <div className="bg-white  flex flex-col items-center overflow-scroll scroll-box">
+        {places &&
+          places.map((place, index) => (
+            <div
+              key={place.id}
+              className="flex flex-col w-[90%] mb-4 py-6 pl-20 pr-5 rounded-lg bg-white hover:cursor-pointer"
+            >
+              <div className="flex justify-between items-center mb-2">
+                <h2
+                  className="text-2xl font-bold font-main"
+                  onClick={() => onPlaceClick(place.id, places)}
+                >
+                  {place.name}
+                </h2>
+                <div className="flex space-x-2">
+                  <button
+                    onClick={() => onMoveUp(index)}
+                    disabled={index === 0}
+                    className="px-2 py-1 rounded disabled:opacity-50"
+                  >
+                    <img src="/assets/UP.svg" alt="위로" className="w-6 h-6" />
+                  </button>
+                  <button
+                    onClick={() => onMoveDown(index)}
+                    disabled={index === places.length - 1}
+                    className="px-2 py-1 rounded disabled:opacity-50"
+                  >
+                    <img
+                      src="/assets/DOWN.svg"
+                      alt="아래로"
+                      className="w-6 h-6"
+                    />
+                  </button>
+                  <button
+                    onClick={() => onDelete(index)}
+                    className="px-2 py-1 rounded"
+                  >
+                    <img
+                      src="/assets/delete-icon.svg"
+                      alt="삭제"
+                      className="w-6 h-6"
+                    />
+                  </button>
+                </div>
+              </div>
+              <img
+                src={place.imageUrl}
+                alt="장소 사진"
+                className="w-80 h-[150px] object-cover my-3.5"
+                onClick={() => onPlaceClick(place.id, places)}
+              />
+            </div>
+          ))}
       </div>
     </div>
   );

--- a/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
@@ -71,10 +71,14 @@ export default function TravelCalendar({ planName }: { planName: string }) {
   };
 
   function handleClickCompletButton() {
-    dispatch(changePlanName(planName));
-    dispatch(changeStartDate(dateState.startDate));
-    dispatch(changeEndDate(dateState.endDate));
-    navigate(`/travel-plan-all`);
+    if (dateState.startDate && dateState.endDate) {
+      dispatch(changePlanName(planName));
+      dispatch(changeStartDate(dateState.startDate.toDateString()));
+      dispatch(changeEndDate(dateState.endDate.toDateString()));
+      navigate(`/travel-plan-all`);
+    }
+
+    return;
   }
 
   return (

--- a/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
+++ b/src/components/travel-plans-list/modal-content/TravelCalendar.tsx
@@ -18,41 +18,11 @@ import { isEarlierDate } from '@utils/date';
 export default function TravelCalendar({ planName }: { planName: string }) {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
-  // const [dates, setDates] = useState<travelDates>({
-  //   startDate: null,
-  //   endDate: null,
-  // });
 
   const [dateState, dateDispatch] = useReducer(
     calendarReducerFn,
     calendarInitialState
   );
-
-  // const onDateChange = (value: Date) => {
-  //   console.log(typeof value);
-  //   const { startDate, endDate } = dates;
-
-  //   if (!startDate || (startDate && endDate)) {
-  //     // start가 없거나, 둘다 차있으면 새로 고르는걸 start로, 나머지는 null로
-  //     setDates({ startDate: value, endDate: null });
-  //   } else if (startDate && !endDate) {
-  //     const newEndDate = value;
-  //     const diffInDays =
-  //       (+newEndDate - +new Date(startDate)) / (1000 * 60 * 60 * 24);
-
-  //     if (diffInDays < 0) {
-  //       alert('종료일은 시작일보다 나중이어야 합니다!');
-  //       return;
-  //     }
-
-  //     if (diffInDays > 5) {
-  //       alert('시작일과 종료일의 차이는 최대 5일이어야 합니다!');
-  //       return;
-  //     } else {
-  //       setDates({ startDate, endDate: newEndDate });
-  //     }
-  //   }
-  // };
 
   const onDateClick = (incomingDate: Date) => {
     if (dateState.startDate === null && dateState.endDate === null) {
@@ -73,8 +43,6 @@ export default function TravelCalendar({ planName }: { planName: string }) {
       dateDispatch({ type: 'isPrevStartDayAndIsPrevEndDay', incomingDate });
     }
   };
-
-  // console.log(dateState);
 
   const tileClassName = ({ date, view }: { date: Date; view: string }) => {
     const { startDate, endDate } = dateState;

--- a/src/context/slices/travel-plan-slice.ts
+++ b/src/context/slices/travel-plan-slice.ts
@@ -1,7 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { travelDates } from '@_types/type';
 
-const initialTravelPlanState: travelDates & { name: string | null } = {
+interface travelPlanStateProps {
+  name: string | null;
+  startDate: string | null;
+  endDate: string | null;
+}
+
+const initialTravelPlanState: travelPlanStateProps = {
   name: null,
   startDate: null,
   endDate: null,
@@ -14,10 +19,10 @@ const travelPlanSlice = createSlice({
     changePlanName: (state, action: PayloadAction<string | null>) => {
       state.name = action.payload;
     },
-    changeStartDate: (state, action: PayloadAction<Date | null>) => {
+    changeStartDate: (state, action: PayloadAction<string | null>) => {
       state.startDate = action.payload;
     },
-    changeEndDate: (state, action: PayloadAction<Date | null>) => {
+    changeEndDate: (state, action: PayloadAction<string | null>) => {
       state.endDate = action.payload;
     },
   },

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -8,3 +8,14 @@ export const isEarlierDate = (firstDate: Date, secondDate: Date): number => {
     return 3;
   }
 };
+
+export const getDateDiff = (
+  firstDate: string | Date,
+  secondDate: string | Date
+): number => {
+  return (
+    Math.abs(new Date(firstDate).getTime() - new Date(secondDate).getTime()) /
+      (1000 * 60 * 60 * 24) +
+    1
+  );
+};


### PR DESCRIPTION
지금 리팩토링되어야 할 로직이 좀 많습니다 찬영님.
기존에는 찬영님께서 `loadSavedPlaces` 함수를 통해 저장된 것을 불러왔는데, 우리 웹 페이지는 현재 모든 차수에 이를 넣어줘야 합니다. 따라서 상태값을 받아온 데이터를 총 차수에 맞게 2차원 배열로 유지할 필요가 있습니다.
일단 제가 여행 계획서 생성 페이지에서 전역 상태 관리로 해당 정보들을 넘겼습니다. 지금 redux 관련 공부 어느 정도 되셨는지 궁금합니다!
또한 PlanListAll 컴포넌트에서 `selectedDayIndex`라는 상태를 하나 만들어줬어요. 이는 prop drilling으로 하위 컴포넌트로 내려가며 사용자가 특정 차수를 선택하면 상태가 바뀌어 이와 연계된 `BookMarkedPlaces` 상태가 바뀌어 하위 컴포넌트로 전달됩니다.

이 과정에서 타입 스크립트가 자동으로 에러를 검출해주어, 그래도 꽤나 편했던 것 같아요. 이외에 제가 생각하는 수정 사항들은 issue로 발행하도록 하겠습니다. 