### PR TITLE
Feat/seungwan travel plan all

### DIFF
--- a/src/components/travel-plan-all/PlanListAll.tsx
+++ b/src/components/travel-plan-all/PlanListAll.tsx
@@ -116,7 +116,13 @@ export default function PlanListAll() {
   return (
     <main className="flex h-[calc(100vh-160px)]">
       {showDetails ? (
-        <TravelPlanDetails onBackClick={handleBackClick} places={places} />
+        <TravelPlanDetails
+          onBackClick={handleBackClick}
+          places={places}
+          travelPlanName={travelPlanName as string}
+          travelStartDate={new Date(travelPlanStartDate)}
+          travelEndDate={new Date(travelPlanEndDate)}
+        />
       ) : (
         <div className="flex w-full h-full overflow-y-scroll">
           <div

--- a/src/components/travel-plan-all/TravelPlanDetails.tsx
+++ b/src/components/travel-plan-all/TravelPlanDetails.tsx
@@ -9,7 +9,7 @@ export default function TravelPlanDetails({
   return (
     <>
       <OverallLeftSection onBackClick={onBackClick} places={places} />
-      <OverallRightSection />
+      <OverallRightSection places={places} />
     </>
   );
 }

--- a/src/components/travel-plan-all/TravelPlanDetails.tsx
+++ b/src/components/travel-plan-all/TravelPlanDetails.tsx
@@ -1,14 +1,15 @@
 import { TravelPlanDetailsProps } from '@_types/type';
+import OverallLeftSection from './overall/OverallLeftSection';
+import OverallRightSection from './overall/OverallRightSection';
 
-
-const TravelPlanDetails: React.FC<TravelPlanDetailsProps> = ({ onBackClick }) => {
+export default function TravelPlanDetails({
+  onBackClick,
+  places,
+}: TravelPlanDetailsProps) {
   return (
-    <div>
-      <button onClick={onBackClick}>뒤로가기</button>
-      <h1>전체 일정 페이지</h1>
-      {/* 전체 일정 보여주기 */}
-    </div>
+    <>
+      <OverallLeftSection onBackClick={onBackClick} places={places} />
+      <OverallRightSection />
+    </>
   );
-};
-
-export default TravelPlanDetails;
+}

--- a/src/components/travel-plan-all/TravelPlanDetails.tsx
+++ b/src/components/travel-plan-all/TravelPlanDetails.tsx
@@ -5,10 +5,19 @@ import OverallRightSection from './overall/OverallRightSection';
 export default function TravelPlanDetails({
   onBackClick,
   places,
+  travelPlanName,
+  travelStartDate,
+  travelEndDate,
 }: TravelPlanDetailsProps) {
   return (
     <>
-      <OverallLeftSection onBackClick={onBackClick} places={places} />
+      <OverallLeftSection
+        onBackClick={onBackClick}
+        places={places}
+        travelPlanName={travelPlanName}
+        travelStartDate={travelStartDate}
+        travelEndDate={travelEndDate}
+      />
       <OverallRightSection places={places} />
     </>
   );

--- a/src/components/travel-plan-all/bookmarkedPlaceList.tsx
+++ b/src/components/travel-plan-all/bookmarkedPlaceList.tsx
@@ -30,11 +30,18 @@ export default function BookmarkedPlaceList({
 }: BookmarkedPlaceListProps) {
   return (
     <div className="h-full w-full flex">
-      <div id="day-selectionarea" className="w-[66px] h-full bg-gray-200">
+      <div
+        id="day-selectionarea"
+        className="!w-[60px] h-ful flex flex-col items-end bg-gray-200 pt-3"
+      >
         {[...Array(totalTravelDay).keys()]
           .map((i) => i + 1)
           .map((dayIndex) => (
-            <div key={dayIndex} onClick={() => handleSelectedDay(dayIndex - 1)}>
+            <div
+              key={dayIndex}
+              onClick={() => handleSelectedDay(dayIndex - 1)}
+              className="bg-[#ffabab] mb-3 text-2 w-[90%] h-12 rounded-tl-lg rounded-bl-lg flex justify-center items-center"
+            >
               {dayIndex}일 차
             </div>
           ))}

--- a/src/components/travel-plan-all/overall/OverallLeftSection.tsx
+++ b/src/components/travel-plan-all/overall/OverallLeftSection.tsx
@@ -1,0 +1,78 @@
+import { formatDateToYYYYMMDD } from '@utils/date';
+import { planListAllPlaceItem } from '@_types/type';
+import { useState, useEffect } from 'react';
+import { fetchSavedPlaces } from '@utils/fetchFunctions';
+
+interface overallLeftSectionProp {
+  onBackClick: () => void;
+  places: planListAllPlaceItem[][];
+}
+
+export default function OverallLeftSection({
+  onBackClick,
+  places,
+}: overallLeftSectionProp) {
+  // savedPlaces는 북마크 되어있는 장소들을 의미해서 여기에서 그냥 한번 더 가져온다. 추후에 리팩터링 가능
+  const [savedPlaces, setSavedPlaces] = useState<planListAllPlaceItem[]>([]);
+
+  useEffect(() => {
+    const loadSavedPlaces = async () => {
+      try {
+        const data = await fetchSavedPlaces();
+        setSavedPlaces(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    loadSavedPlaces();
+  }, []);
+
+  return (
+    <div id="overall-left-section" className="w-[35%] bg-[#F3F5FF] flex">
+      <div
+        id="tag-area"
+        className="w-[100px] flex flex-col justify-start items-end pt-[30px]"
+      >
+        <p
+          className="bg-[#B1B1B1] w-[72px] h-[90px] flex justify-center items-center rounded-tl-lg rounded-bl-lg hover:cursor-pointer"
+          onClick={onBackClick}
+        >
+          전체일정
+        </p>
+      </div>
+      <div
+        id="places-area"
+        className="grow flex flex-col bg-white overflow-y-scroll scroll-box"
+      >
+        <div className="w-full flex justify-between items-center mb-10">
+          <span>여행지</span>
+          <span>
+            {formatDateToYYYYMMDD(
+              localStorage.getItem('travelPlanStartDate') as string
+            )}
+            ~
+            {formatDateToYYYYMMDD(
+              localStorage.getItem('travelPlanEndDate') as string
+            )}
+          </span>
+        </div>
+        <span className="mb-5">저장된 장소</span>
+        {savedPlaces.map((savedPlacesItems, idx) => {
+          return (
+            <div
+              key={savedPlacesItems.id}
+              className="flex justify-between items-center"
+            >
+              <img
+                src={savedPlacesItems.imageUrl}
+                alt="장소"
+                className="w-[80%] h-[80%]"
+              />
+              <span id="장소 이름">{savedPlacesItems.name}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/travel-plan-all/overall/OverallLeftSection.tsx
+++ b/src/components/travel-plan-all/overall/OverallLeftSection.tsx
@@ -28,7 +28,10 @@ export default function OverallLeftSection({
   }, []);
 
   return (
-    <div id="overall-left-section" className="w-[35%] bg-[#F3F5FF] flex">
+    <div
+      id="overall-left-section"
+      className="w-[35%] bg-[#F3F5FF] flex font-main"
+    >
       <div
         id="tag-area"
         className="w-[100px] flex flex-col justify-start items-end pt-[30px]"

--- a/src/components/travel-plan-all/overall/OverallLeftSection.tsx
+++ b/src/components/travel-plan-all/overall/OverallLeftSection.tsx
@@ -2,18 +2,26 @@ import { formatDateToYYYYMMDD } from '@utils/date';
 import { planListAllPlaceItem } from '@_types/type';
 import { useState, useEffect } from 'react';
 import { fetchSavedPlaces } from '@utils/fetchFunctions';
+import { useNavigate } from 'react-router-dom';
 
 interface overallLeftSectionProp {
   onBackClick: () => void;
   places: planListAllPlaceItem[][];
+  travelPlanName: string;
+  travelStartDate: Date;
+  travelEndDate: Date;
 }
 
 export default function OverallLeftSection({
   onBackClick,
   places,
+  travelPlanName,
+  travelStartDate,
+  travelEndDate,
 }: overallLeftSectionProp) {
   // savedPlaces는 북마크 되어있는 장소들을 의미해서 여기에서 그냥 한번 더 가져온다. 추후에 리팩터링 가능
   const [savedPlaces, setSavedPlaces] = useState<planListAllPlaceItem[]>([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const loadSavedPlaces = async () => {
@@ -26,6 +34,36 @@ export default function OverallLeftSection({
     };
     loadSavedPlaces();
   }, []);
+
+  const handleSaveTravelPlan = async () => {
+    // 백엔드 엔드포인트로 전송하고, 로컬 스토리지를 비우는 로직. 추후에 travel-plans-list 페이지로 이동
+    const sendingTravelPlanObject = {
+      name: travelPlanName,
+      startDate: travelStartDate.toDateString(),
+      endDate: travelEndDate.toDateString(),
+      dailyPlans: places,
+    };
+
+    const response = await fetch(
+      `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/plan`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(sendingTravelPlanObject),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error('여행 계획 저장이 실패했습니다.');
+    } else {
+      localStorage.removeItem('travelPlanName');
+      localStorage.removeItem('travelPlanStartDate');
+      localStorage.removeItem('travelPlanEndDate');
+      navigate('/travel-plans-list');
+    }
+  };
 
   return (
     <div
@@ -45,7 +83,7 @@ export default function OverallLeftSection({
       </div>
       <div
         id="places-area"
-        className="grow flex flex-col bg-white overflow-y-scroll scroll-box"
+        className="grow flex flex-col bg-white overflow-y-scroll scroll-box items-center"
       >
         <div className="w-full flex justify-between items-center mb-10">
           <span>여행지</span>
@@ -59,22 +97,34 @@ export default function OverallLeftSection({
             )}
           </span>
         </div>
-        <span className="mb-5">저장된 장소</span>
+        <span className="mb-5 w-full">저장된 장소</span>
         {savedPlaces.map((savedPlacesItems, idx) => {
           return (
             <div
               key={savedPlacesItems.id}
-              className="flex justify-between items-center"
+              className="flex justify-between items-center w-[90%] mb-[30px]"
             >
-              <img
-                src={savedPlacesItems.imageUrl}
-                alt="장소"
-                className="w-[80%] h-[80%]"
-              />
-              <span id="장소 이름">{savedPlacesItems.name}</span>
+              <div className="grow">
+                <img
+                  src={savedPlacesItems.imageUrl}
+                  alt="장소"
+                  className="object-none rounded-xl"
+                />
+              </div>
+
+              <span id="장소 이름" className="min-w-[30%] text-center">
+                {savedPlacesItems.name}
+              </span>
             </div>
           );
         })}
+
+        <button
+          className="w-[80%] rounded-lg text-[25px] text-white bg-textPurple"
+          onClick={handleSaveTravelPlan}
+        >
+          계획 저장하기
+        </button>
       </div>
     </div>
   );

--- a/src/components/travel-plan-all/overall/OverallRightSection.tsx
+++ b/src/components/travel-plan-all/overall/OverallRightSection.tsx
@@ -1,0 +1,7 @@
+export default function OverallRightSection() {
+  return (
+    <div id="overall-right-section" className="w-[65%]">
+      ho
+    </div>
+  );
+}

--- a/src/components/travel-plan-all/overall/OverallRightSection.tsx
+++ b/src/components/travel-plan-all/overall/OverallRightSection.tsx
@@ -1,7 +1,25 @@
-export default function OverallRightSection() {
+import { planListAllPlaceItem } from '@_types/type';
+import OverallRightSectionOneDayItem from './OverallRightSectionOneDayItem';
+
+interface overallRightSectionProps {
+  places: planListAllPlaceItem[][];
+}
+
+export default function OverallRightSection({
+  places,
+}: overallRightSectionProps) {
   return (
-    <div id="overall-right-section" className="w-[65%]">
-      ho
+    <div
+      id="overall-right-section"
+      className="w-[65%] travel-plan-scroll-box flex font-main"
+    >
+      {places.map((place, idx) => (
+        <OverallRightSectionOneDayItem
+          key={idx}
+          placeList={place}
+          dayIndex={idx + 1}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
+++ b/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
@@ -19,17 +19,19 @@ export default function OverallRightSectionOneDayItem({
         <div
           key={placeListItem.id}
           id="placeListItem-container"
-          className="flex flex-col w-full h-[300px] mb-[60px]"
+          className="flex flex-col items-center w-full h-[300px] mb-[60px]"
         >
-          <div className="flex justify-between items-center">
-            <span>{placeListItem.name}</span>
+          <div className="flex w-[90%] justify-between items-center">
+            <span className="">{placeListItem.name}</span>
             {/* 위, 아래와 삭제 버튼이 위치하면 됩니다. */}
           </div>
-          <img
-            src={placeListItem.imageUrl}
-            alt="장소이미지"
-            className="w-[80%] h-[80%]"
-          />
+          <div className="w-[90%] flex ">
+            <img
+              src={placeListItem.imageUrl}
+              alt="장소이미지"
+              className="w-[80%]  rounded-xl"
+            />
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
+++ b/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
@@ -1,0 +1,37 @@
+import { planListAllPlaceItem } from '@_types/type';
+
+interface overallRightSectionOneDayItemProps {
+  placeList: planListAllPlaceItem[];
+  dayIndex: number;
+}
+
+export default function OverallRightSectionOneDayItem({
+  placeList,
+  dayIndex,
+}: overallRightSectionOneDayItemProps) {
+  return (
+    <div className="w-fit min-w-[500px] h-full flex flex-col justify-start items-center">
+      <div className="mt-[35px] mb-[60px] w-full text-black font-main">
+        Day{dayIndex}
+      </div>
+
+      {placeList.map((placeListItem) => (
+        <div
+          key={placeListItem.id}
+          id="placeListItem-container"
+          className="flex flex-col w-full h-[300px] mb-[60px]"
+        >
+          <div className="flex justify-between items-center">
+            <span>{placeListItem.name}</span>
+            {/* 위, 아래와 삭제 버튼이 위치하면 됩니다. */}
+          </div>
+          <img
+            src={placeListItem.imageUrl}
+            alt="장소이미지"
+            className="w-[80%] h-[80%]"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,15 @@
   .scroll-box::-webkit-scrollbar {
     display: none;
   }
+
+  .travel-plan-scroll-box {
+    overflow-x: scroll;
+    -ms-overflow-style: none;
+  }
+
+  .travel-plan-scroll-box::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 @layer components {

--- a/src/types/type.tsx
+++ b/src/types/type.tsx
@@ -116,4 +116,7 @@ export interface BookmarkedPlaceListProps {
 export interface TravelPlanDetailsProps {
   onBackClick: () => void;
   places: planListAllPlaceItem[][];
+  travelPlanName: string;
+  travelStartDate: Date;
+  travelEndDate: Date;
 }

--- a/src/types/type.tsx
+++ b/src/types/type.tsx
@@ -92,8 +92,13 @@ export interface travelDates {
   endDate: Date | null;
 }
 
-
 // travel-plan-all 관련 타입
+
+export interface planListAllPlaceItem {
+  id: string;
+  name: string;
+  imageUrl: string;
+}
 
 export interface PlaceChatProps {
   place: SelectPlacePlace;
@@ -110,4 +115,5 @@ export interface BookmarkedPlaceListProps {
 
 export interface TravelPlanDetailsProps {
   onBackClick: () => void;
+  places: planListAllPlaceItem[][];
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -19,3 +19,16 @@ export const getDateDiff = (
     1
   );
 };
+
+export const formatDateToYYYYMMDD = (dateString: string): string => {
+  // 입력된 날짜 문자열을 Date 객체로 변환
+  const date = new Date(dateString);
+
+  // 년, 월, 일을 추출
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0'); // 월은 0부터 시작하므로 1을 더해줍니다.
+  const day = String(date.getDate()).padStart(2, '0'); // 일자를 2자리로 맞추기 위해 padStart를 사용합니다.
+
+  // 원하는 포맷으로 문자열을 생성
+  return `${year}.${month}.${day}`;
+};


### PR DESCRIPTION
/travel-plan-all 페이지에서 기존의 모달로부터 넘어와 로컬스토리지에서 계획 이름, 시작과 종료일을 꺼내 계획을 저장 후 생성하는 로직을 완성했습니다.

다만... 작업을 하면서 몇가지 드는 생각이 있어요. 
1. 이게 아무래도 다음부터는 확실히 페이지를 저희 둘이 구분해서 진행하면 좋을 것 같아요. 아무래도 제가 먼저 작성하기 시작한 페이지 컴포넌트가 아니다보니 전체적인 구조를 파악하는 데에 어려움이 좀 있었던 것 같아요.
2. 현재 `places`, `BookMarkedPlaces`와 같은 상태나 변수의 네이밍이 존재하는 것 같은데 조금 더 semantic한 네이밍이면 좋지 않을까 싶습니다. 사실 places라는 단어는 너무 애매모호하다고 생각합니다. 현재 전자의 경우에는 백엔드로부터 받아온 좋아요한 장소들을 차수만큼 곱해서 나중에 결국 여행 계획을 저장하는 데에 쓰이고 `bookMarkedPlaces` 같은 경우에는 해당 차수의 장소들을 말하잖아요. 둘다 어찌보면 bookmark인데 이렇게 네이밍하면 추후에 헷갈릴 여지가 있다고 생각합니다.
3. 특정 UI를 새로운 url로 파서 보여줄지, 아니면 동일페이지 내에서 상태를 분기쳐서 보여줄지 설계를 잘 하고 들어가면 좋을 것 같아요. 사실 페이지가 늘어난다는 것은 나중에 저희가 관리할 코드의 복잡도가 늘어날수도? 있다고 생각합니다. 이번에 찬영님께서 showDetails라는 상태로 페이지 URL 자체를 바꾸지 않고 처리해주신 것 참 좋았던 것 같아요. 페이지가 바뀌면 DOM이 전부 언마운트 되어서 여행 계획명, 시작과 종료일 같은 정보를 모두 상위 컴포넌트로 끌어올리거나 전역 상태로 바꿔주는 번거로움이 수반될 수 있거든요!
다만 여기에서도 `showDetails`라는 네이밍은 개인적으로 조금 아쉬운 것 같아요. 전체 일정을 보러가는 것이면 `isOverallPlans`와 같은 상태 명이 조금 더 낫지 않나라는 생각이 듭니다.
4. 그리고 리액트의 함수형 컴포넌트를 이용할 때 저희끼리 함수 선언식으로 할지, 표현식으로 할지 조금 더 통일됐으면 좋겠다는 생각입니다. 일단 저희가 기존에 함수 선언식 방식으로 하고 있어서 관련된 코드는 수정해놨습니다.
5. 일단 네이밍이 적절한 것이 생각나지 않는다면 주석으로 본인의 의도를 충분히 설명해놓고 넘어가는 것도 좋다고 생각해요. 마찬가지로 핸들러 함수를 만들 때에도 함수의 도입부에 어떤 기능을 할 수 있는 함수임을 설명해주는 것도 참 좋은 것 같구요.

고생하셨습니다.