### PR TITLE
Fix/plan list

### DIFF
--- a/src/components/travel-plan-all/bookmarkedPlaceList.tsx
+++ b/src/components/travel-plan-all/bookmarkedPlaceList.tsx
@@ -32,7 +32,7 @@ export default function BookmarkedPlaceList({
     <div className="h-full w-full flex">
       <div
         id="day-selectionarea"
-        className="!w-[60px] h-ful flex flex-col items-end bg-gray-200 pt-3"
+        className="w-[65px] h-ful flex flex-col items-end bg-gray-200 pt-3"
       >
         {[...Array(totalTravelDay).keys()]
           .map((i) => i + 1)

--- a/src/components/travel-plan-all/overall/OverallLeftSection.tsx
+++ b/src/components/travel-plan-all/overall/OverallLeftSection.tsx
@@ -1,6 +1,6 @@
 import { formatDateToYYYYMMDD } from '@utils/date';
 import { planListAllPlaceItem } from '@_types/type';
-import { useState, useEffect, memo } from 'react';
+import { useState, useEffect } from 'react';
 import { fetchSavedPlaces } from '@utils/fetchFunctions';
 import { useNavigate } from 'react-router-dom';
 
@@ -19,11 +19,8 @@ export default function OverallLeftSection({
   travelStartDate,
   travelEndDate,
 }: overallLeftSectionProp) {
-  // savedPlaces는 북마크 되어있는 장소들을 의미해서 여기에서 그냥 한번 더 가져온다. 추후에 리팩터링 가능
   const [savedPlaces, setSavedPlaces] = useState<planListAllPlaceItem[]>([]);
   const navigate = useNavigate();
-
-  console.log(places);
 
   useEffect(() => {
     const loadSavedPlaces = async () => {
@@ -38,29 +35,17 @@ export default function OverallLeftSection({
   }, []);
 
   const handleSaveTravelPlan = async () => {
-    // 백엔드 엔드포인트로 전송하고, 로컬 스토리지를 비우는 로직. 추후에 travel-plans-list 페이지로 이동
-
-    const sendingTravelPlanObject: {
-      name: string;
-      startDate: string;
-      endDate: string;
-      dailyPlans: { dailyPlanItems: { placeId: string; memo: string }[] }[];
-    } = {
+    const sendingTravelPlanObject = {
       name: travelPlanName,
       startDate: formatDateToYYYYMMDD(travelStartDate.toDateString()),
       endDate: formatDateToYYYYMMDD(travelEndDate.toDateString()),
-      dailyPlans: [],
+      dailyPlans: places.map((place) => ({
+        dailyPlanItems: place.map((placeItem) => ({
+          placeId: placeItem.id,
+          memo: '',
+        })),
+      })),
     };
-
-    for (const place of places) {
-      const dailyPlanItemsArray = [];
-      for (const placeItem of place) {
-        dailyPlanItemsArray.push({ placeId: placeItem.id, memo: '' });
-      }
-
-      const pushingObect = { dailyPlanItems: dailyPlanItemsArray };
-      sendingTravelPlanObject.dailyPlans.push(pushingObect);
-    }
 
     const response = await fetch(
       `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/plan`,
@@ -90,22 +75,31 @@ export default function OverallLeftSection({
     >
       <div
         id="tag-area"
-        className="w-[100px] flex flex-col justify-start items-end pt-[30px]"
+        className="w-[52px] flex flex-col justify-start items-end pt-4"
       >
+        <div className="bg-white w-[50px] h-[50px] flex flex-col justify-center items-center rounded-md hover:cursor-pointer">
+          <img
+            src="/assets/Arrow.svg"
+            alt="뒤로 가기"
+            className="w-10 h-10"
+            onClick={onBackClick}
+          />
+        </div>
+        <div className='pb-4'> </div>
         <p
-          className="bg-[#B1B1B1] w-[72px] h-[90px] flex justify-center items-center rounded-tl-lg rounded-bl-lg hover:cursor-pointer"
-          onClick={onBackClick}
+          className="bg-[#B1B1B1] w-[52px] h-[102px] flex flex-col justify-center items-center rounded-tl-2xl rounded-bl-2xl"
         >
-          전체일정
+          <span>전체</span>
+          <span>일정</span>
         </p>
       </div>
       <div
         id="places-area"
-        className="grow flex flex-col bg-white overflow-y-scroll scroll-box items-center"
+        className="grow flex flex-col bg-white w-[375px] mr-2 rounded-xl overflow-y-scroll scroll-box items-center"
       >
-        <div className="w-full flex justify-between items-center mb-10">
-          <span>여행지</span>
-          <span>
+        <div className="w-full flex justify-between items-center my-10">
+          <span className="text-4xl ml-6">여행지</span>
+          <span className="text-gray-400 text-xl mr-6">
             {formatDateToYYYYMMDD(
               localStorage.getItem('travelPlanStartDate') as string
             )}
@@ -115,22 +109,21 @@ export default function OverallLeftSection({
             )}
           </span>
         </div>
-        <span className="mb-5 w-full">저장된 장소</span>
-        {savedPlaces.map((savedPlacesItems, idx) => {
+        <span className="text-2xl font-text font-bold mb-5 w-full ml-12">저장된 장소</span>
+        {savedPlaces.map((savedPlacesItems) => {
           return (
             <div
               key={savedPlacesItems.id}
-              className="flex justify-between items-center w-[90%] mb-[30px]"
+              className="flex items-center w-[90%] mb-6"
             >
-              <div className="grow">
+              <div className="flex-shrink-0 mr-4">
                 <img
                   src={savedPlacesItems.imageUrl}
                   alt="장소"
-                  className="object-none rounded-xl"
+                  className="w-44 h-24 object-cover rounded-xl"
                 />
               </div>
-
-              <span id="장소 이름" className="min-w-[30%] text-center">
+              <span id="장소 이름" className="text-xl text-center w-full">
                 {savedPlacesItems.name}
               </span>
             </div>
@@ -138,7 +131,7 @@ export default function OverallLeftSection({
         })}
 
         <button
-          className="w-[80%] rounded-lg text-[25px] text-white bg-textPurple"
+          className="w-[80%] h-14 flex-shrink-0 rounded-lg text-[25px] text-white bg-textPurple mt-6 mb-2"
           onClick={handleSaveTravelPlan}
         >
           계획 저장하기

--- a/src/components/travel-plan-all/overall/OverallRightSection.tsx
+++ b/src/components/travel-plan-all/overall/OverallRightSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { planListAllPlaceItem } from '@_types/type';
 import OverallRightSectionOneDayItem from './OverallRightSectionOneDayItem';
 
@@ -5,19 +6,49 @@ interface overallRightSectionProps {
   places: planListAllPlaceItem[][];
 }
 
-export default function OverallRightSection({
-  places,
-}: overallRightSectionProps) {
+export default function OverallRightSection({ places }: overallRightSectionProps) {
+  const [placeList, setPlaceList] = useState(places);
+
+  const handleMoveUp = (dayIndex: number, placeIndex: number) => {
+    if (placeIndex > 0) {
+      const updatedPlaces = [...placeList];
+      const temp = updatedPlaces[dayIndex][placeIndex - 1];
+      updatedPlaces[dayIndex][placeIndex - 1] = updatedPlaces[dayIndex][placeIndex];
+      updatedPlaces[dayIndex][placeIndex] = temp;
+      setPlaceList(updatedPlaces);
+    }
+  };
+
+  const handleMoveDown = (dayIndex: number, placeIndex: number) => {
+    if (placeIndex < placeList[dayIndex].length - 1) {
+      const updatedPlaces = [...placeList];
+      const temp = updatedPlaces[dayIndex][placeIndex + 1];
+      updatedPlaces[dayIndex][placeIndex + 1] = updatedPlaces[dayIndex][placeIndex];
+      updatedPlaces[dayIndex][placeIndex] = temp;
+      setPlaceList(updatedPlaces);
+    }
+  };
+
+  const handleDelete = (dayIndex: number, placeIndex: number) => {
+    const updatedPlaces = placeList.map((dayPlaces, index) => {
+      if (index === dayIndex) {
+        return dayPlaces.filter((_, idx) => idx !== placeIndex);
+      }
+      return dayPlaces;
+    });
+    setPlaceList(updatedPlaces);
+  };
+
   return (
-    <div
-      id="overall-right-section"
-      className="w-[65%] travel-plan-scroll-box flex font-main"
-    >
-      {places.map((place, idx) => (
+    <div id="overall-right-section" className="w-[65%] h-full travel-plan-scroll-box flex font-main overflow-x-auto">
+      {placeList.map((place, idx) => (
         <OverallRightSectionOneDayItem
           key={idx}
           placeList={place}
-          dayIndex={idx + 1}
+          dayIndex={idx}
+          onMoveUp={handleMoveUp}
+          onMoveDown={handleMoveDown}
+          onDelete={handleDelete}
         />
       ))}
     </div>

--- a/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
+++ b/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
@@ -3,37 +3,89 @@ import { planListAllPlaceItem } from '@_types/type';
 interface overallRightSectionOneDayItemProps {
   placeList: planListAllPlaceItem[];
   dayIndex: number;
+  onMoveUp: (dayIndex: number, placeIndex: number) => void;
+  onMoveDown: (dayIndex: number, placeIndex: number) => void;
+  onDelete: (dayIndex: number, placeIndex: number) => void;
 }
 
 export default function OverallRightSectionOneDayItem({
   placeList,
   dayIndex,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
 }: overallRightSectionOneDayItemProps) {
   return (
-    <div className="w-fit min-w-[500px] h-full flex flex-col justify-start items-center">
-      <div className="mt-[35px] mb-[60px] w-full text-black font-main">
-        Day{dayIndex}
+    <div className="w-fit min-w-[500px] h-full flex flex-col pt-5 pl-10 border-t-[5px] border-b-[5px] border-l-[1px] border-r-[1px] border-black rounded-lg bg-white">
+      <div className="mb-6 text-black text-xl font-main">
+        Day {dayIndex + 1}
       </div>
 
-      {placeList.map((placeListItem) => (
-        <div
-          key={placeListItem.id}
-          id="placeListItem-container"
-          className="flex flex-col items-center w-full h-[300px] mb-[60px]"
-        >
-          <div className="flex w-[90%] justify-between items-center">
-            <span className="">{placeListItem.name}</span>
-            {/* 위, 아래와 삭제 버튼이 위치하면 됩니다. */}
+      <div className="relative w-full">
+        {/* 시간선 표시 */}
+        <div className="absolute left-4 top-0 bottom-0 w-[1px] bg-black"></div>
+        {placeList.map((placeListItem, placeIndex) => (
+          <div
+            key={placeListItem.id}
+            className="flex w-full relative mb-12 items-start"
+          >
+            {/* 장소 이름 표시 */}
+            <div className="absolute left-3 top-0 flex items-center">
+              <div className="w-3 h-3 rounded-full bg-planListRed"></div>
+            </div>
+            {/* 장소 정보 및 장소 순서 변경 버튼 */}
+            <div className="flex-grow flex flex-col ml-10">
+              <div className="flex justify-between items-center">
+                <div className="flex items-center">
+                  <h2 className="text-lg font-bold font-main ml-14">
+                    {placeListItem.name}
+                  </h2>
+                </div>
+                <div className="flex mr-10">
+                  <button
+                    onClick={() => onMoveUp(dayIndex, placeIndex)}
+                    disabled={placeIndex === 0}
+                    className="px-1 rounded"
+                  >
+                    <img src="/assets/UP.svg" alt="위로" />
+                  </button>
+                  <button
+                    onClick={() => onMoveDown(dayIndex, placeIndex)}
+                    disabled={placeIndex === placeList.length - 1}
+                    className="px-1 rounded"
+                  >
+                    <img src="/assets/DOWN.svg" alt="아래로" />
+                  </button>
+                  <button
+                    onClick={() => onDelete(dayIndex, placeIndex)}
+                    className="px-5"
+                  >
+                    <img
+                      src="/assets/delete-icon.svg"
+                      alt="삭제"
+                      className="w-6 h-6"
+                    />
+                  </button>
+                </div>
+              </div>
+              <div className="mt-4 flex justify-center relative">
+                <img
+                  src={placeListItem.imageUrl}
+                  alt="장소이미지"
+                  className="w-[305px] h-[132px] rounded-xl object-cover"
+                />
+              </div>
+              {/* 메모장 기능 (추후 논의 필요함) */}
+              <div className="mt-2 flex justify-center">
+                <textarea
+                  className="w-[305px] h-[50px] rounded-xl border border-gray-300 p-2"
+                  placeholder="메모장"
+                />
+              </div>
+            </div>
           </div>
-          <div className="w-[90%] flex ">
-            <img
-              src={placeListItem.imageUrl}
-              alt="장소이미지"
-              className="w-[80%]  rounded-xl"
-            />
-          </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
+++ b/src/components/travel-plan-all/overall/OverallRightSectionOneDayItem.tsx
@@ -16,20 +16,12 @@ export default function OverallRightSectionOneDayItem({
   onDelete,
 }: overallRightSectionOneDayItemProps) {
   return (
-    <div className="w-fit min-w-[500px] h-full flex flex-col pt-5 pl-10 border-t-[5px] border-b-[5px] border-l-[1px] border-r-[1px] border-black rounded-lg bg-white">
-      <div className="mb-6 text-black text-xl font-main">
-        Day {dayIndex + 1}
-      </div>
-
-      <div className="relative w-full">
-        {/* 시간선 표시 */}
+    <div className="w-fit min-w-[500px] h-auto flex flex-col pt-5 pl-10 border-t-[5px] border-r-[1px] border-b-[5px] border-l-[1px] border-black rounded-lg bg-white overflow-y-auto">
+      <div className="mb-6 text-black text-xl font-main">Day {dayIndex + 1}</div>
+      <div className="relative w-full flex-grow">
         <div className="absolute left-4 top-0 bottom-0 w-[1px] bg-black"></div>
         {placeList.map((placeListItem, placeIndex) => (
-          <div
-            key={placeListItem.id}
-            className="flex w-full relative mb-12 items-start"
-          >
-            {/* 장소 이름 표시 */}
+          <div key={placeListItem.id} className="flex w-full relative mb-12 items-start">
             <div className="absolute left-3 top-0 flex items-center">
               <div className="w-3 h-3 rounded-full bg-planListRed"></div>
             </div>
@@ -37,9 +29,7 @@ export default function OverallRightSectionOneDayItem({
             <div className="flex-grow flex flex-col ml-10">
               <div className="flex justify-between items-center">
                 <div className="flex items-center">
-                  <h2 className="text-lg font-bold font-main ml-14">
-                    {placeListItem.name}
-                  </h2>
+                  <h2 className="text-lg font-bold font-main ml-14">{placeListItem.name}</h2>
                 </div>
                 <div className="flex mr-10">
                   <button
@@ -56,15 +46,8 @@ export default function OverallRightSectionOneDayItem({
                   >
                     <img src="/assets/DOWN.svg" alt="아래로" />
                   </button>
-                  <button
-                    onClick={() => onDelete(dayIndex, placeIndex)}
-                    className="px-5"
-                  >
-                    <img
-                      src="/assets/delete-icon.svg"
-                      alt="삭제"
-                      className="w-6 h-6"
-                    />
+                  <button onClick={() => onDelete(dayIndex, placeIndex)} className="px-5">
+                    <img src="/assets/delete-icon.svg" alt="삭제" className="w-6 h-6" />
                   </button>
                 </div>
               </div>

--- a/src/types/type.tsx
+++ b/src/types/type.tsx
@@ -120,3 +120,8 @@ export interface TravelPlanDetailsProps {
   travelStartDate: Date;
   travelEndDate: Date;
 }
+
+export interface overallRightSectionOneDayItemProps {
+  placeList: planListAllPlaceItem[];
+  dayIndex: number;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,7 @@ export default {
         backgroundLightGray: '#F7F8F9',
         borderLightGray: '#d9d9d9',
         chatModalPurple: '#9DA7FF',
+        planListRed:'#FF7878',
       },
       height: {
         travelListSection: 'calc(100% - 160px)',


### PR DESCRIPTION
승완님이 만들어두신 /overall 코드를 수정하여 전체 일정 페이지 스타일링을 구현했습니다. 기존에 전체 일정 페이지에서 '전체일정' 버튼 클릭시 뒤로가기 기능이 구현되어 있었는데 뒤로가기 버튼은 따로 넣고 '전체 일정' 탭으로 수정했습니다. 다른 로직은 이전 페이지를 활용했습니다. 
최대한 flex를 사용해봤는데 더 수정이 필요한 부분이 있다면 알려주시면 감사하겠습니다 🙇‍♀️ 