### PR TITLE
/travel-plan 페이지의 기존 여행 계획 내역 조회 페이지 수정

### DIFF
--- a/src/components/travel-plan/TravelPlanViewLeftSection.tsx
+++ b/src/components/travel-plan/TravelPlanViewLeftSection.tsx
@@ -60,6 +60,9 @@ export default function TravelPlanViewLeftSection({
             </div>
           );
         })}
+      <button className="w-[80%] h-14 flex-shrink-0 rounded-lg font-main text-[25px] text-white bg-textPurple mt-6 mb-2">
+        계획 저장하기
+      </button>
     </div>
   );
 }

--- a/src/components/travel-plan/TravelPlanViewRightSection.tsx
+++ b/src/components/travel-plan/TravelPlanViewRightSection.tsx
@@ -10,13 +10,75 @@ export default function TravelPlanViewRightSection({
   dailyPlans,
   handleTravelPlanData,
 }: travelPlanViewRightSectionProps) {
-  const modifyPlanState = (
+  console.log(dailyPlans);
+  const modifyPlanFunction = (
     dayIndex: number,
     placeOrderIndex: number,
-    actionType: 'up' | 'down' | 'delete'
+    type: 'up' | 'down' | 'delete'
   ): void => {
-    handleTravelPlanData((prevData: travelPlanDataProp | null) => {
-      return prevData;
+    handleTravelPlanData((prevData) => {
+      const newDailyPlansArray: dailyPlansProps[] = [];
+      for (let i = 0; i < dailyPlans.length; i++) {
+        if (i !== dayIndex) {
+          newDailyPlansArray.push(dailyPlans[i]);
+        } else {
+          if (type === 'up') {
+            if (placeOrderIndex === 0) {
+              newDailyPlansArray.push(dailyPlans[i]);
+            } else {
+              const temp = JSON.parse(
+                JSON.stringify(dailyPlans[i].dailyPlanItems[placeOrderIndex])
+              );
+              dailyPlans[i].dailyPlanItems[placeOrderIndex] =
+                dailyPlans[i].dailyPlanItems[placeOrderIndex - 1];
+              dailyPlans[i].dailyPlanItems[placeOrderIndex - 1] = temp;
+              newDailyPlansArray.push({
+                date: dailyPlans[i].date,
+                dayNumber: dailyPlans[i].dayNumber,
+                id: dailyPlans[i].id,
+                dailyPlanItems: dailyPlans[i].dailyPlanItems,
+              });
+            }
+          } else if (type === 'down') {
+            if (
+              placeOrderIndex ===
+              dailyPlans[placeOrderIndex].dailyPlanItems.length - 1
+            ) {
+              newDailyPlansArray.push(dailyPlans[i]);
+            } else {
+              const temp = JSON.parse(
+                JSON.stringify(dailyPlans[i].dailyPlanItems[placeOrderIndex])
+              );
+              dailyPlans[i].dailyPlanItems[placeOrderIndex] =
+                dailyPlans[i].dailyPlanItems[placeOrderIndex + 1];
+              dailyPlans[i].dailyPlanItems[placeOrderIndex + 1] = temp;
+              newDailyPlansArray.push({
+                date: dailyPlans[i].date,
+                dayNumber: dailyPlans[i].dayNumber,
+                id: dailyPlans[i].id,
+                dailyPlanItems: dailyPlans[i].dailyPlanItems,
+              });
+            }
+          } else if (type === 'delete') {
+            const tmpDailyPlanItems = dailyPlans[i].dailyPlanItems.filter(
+              (element, i) => i !== placeOrderIndex
+            );
+            newDailyPlansArray.push({
+              date: dailyPlans[i].date,
+              dayNumber: dailyPlans[i].dayNumber,
+              id: dailyPlans[i].id,
+              dailyPlanItems: tmpDailyPlanItems,
+            });
+          }
+        }
+      }
+      return {
+        id: prevData?.id as number,
+        name: prevData?.name as string,
+        startDate: prevData?.startDate as string,
+        endDate: prevData?.endDate as string,
+        dailyPlans: newDailyPlansArray,
+      };
     });
   };
 
@@ -27,20 +89,39 @@ export default function TravelPlanViewRightSection({
           <div
             className="border-x-[1px] border-y-[5px] rounded-lg overflow-y-scroll border-black min-w-[500px] flex flex-col items-center gap-y-5 pb-10"
             key={planElement.id}
-            onClick={() => {}}
           >
             <div className="w-[65%] mt-[35px] flex justify-start items-center">
               Day {planElement.dayNumber}
             </div>
-            {planElement.dailyPlanItems.map((element) => {
+            {planElement.dailyPlanItems.map((element, index) => {
               return (
                 <div
                   className="w-fit h-fit flex flex-col items-center gap-y-3"
                   key={element.id}
                 >
-                  <p className="w-full flex justify-start">
+                  <div className="w-full flex justify-between items-center">
                     {element.place.name}
-                  </p>
+                    <div className="flex w-fit justify-around items-center gap-x-2">
+                      <img
+                        src="/assets/UP.svg"
+                        alt="This is up svg image file"
+                        className="hover:cursor-pointer"
+                        onClick={() => modifyPlanFunction(idx, index, 'up')}
+                      />
+                      <img
+                        src="/assets/DOWN.svg"
+                        alt="This is down svg image file"
+                        className="hover:cursor-pointer"
+                        onClick={() => modifyPlanFunction(idx, index, 'down')}
+                      />
+                      <img
+                        src="/assets/delete-icon.svg"
+                        alt="This is delete svg image file"
+                        className="w-6 h-6 hover:cursor-pointer"
+                        onClick={() => modifyPlanFunction(idx, index, 'delete')}
+                      />
+                    </div>
+                  </div>
                   <img
                     src={element.place.imageUrl}
                     alt="This is place image"

--- a/src/components/travel-plan/TravelPlanViewRightSection.tsx
+++ b/src/components/travel-plan/TravelPlanViewRightSection.tsx
@@ -11,13 +11,19 @@ export default function TravelPlanViewRightSection({
     <div className="w-[65%] h-full travel-plan-scroll-box flex font-main overflow-x-auto">
       {dailyPlans.map((planElement) => {
         return (
-          <div className="border-x-[1px] border-y-[5px] rounded-lg overflow-y-scroll border-black min-w-[500px] flex flex-col items-center gap-y-5 pb-10">
+          <div
+            className="border-x-[1px] border-y-[5px] rounded-lg overflow-y-scroll border-black min-w-[500px] flex flex-col items-center gap-y-5 pb-10"
+            key={planElement.id}
+          >
             <div className="w-[65%] mt-[35px] flex justify-start items-center">
               Day {planElement.dayNumber}
             </div>
             {planElement.dailyPlanItems.map((element) => {
               return (
-                <div className="w-fit h-fit flex flex-col items-center gap-y-3">
+                <div
+                  className="w-fit h-fit flex flex-col items-center gap-y-3"
+                  key={element.id}
+                >
                   <p className="w-full flex justify-start">
                     {element.place.name}
                   </p>

--- a/src/components/travel-plan/TravelPlanViewRightSection.tsx
+++ b/src/components/travel-plan/TravelPlanViewRightSection.tsx
@@ -7,17 +7,17 @@ interface travelPlanViewRightSectionProps {
 export default function TravelPlanViewRightSection({
   dailyPlans,
 }: travelPlanViewRightSectionProps) {
-  console.log(dailyPlans);
   return (
     <div className="w-[65%] h-full travel-plan-scroll-box flex font-main overflow-x-auto">
-      {dailyPlans.map((planElement, index) => {
+      {dailyPlans.map((planElement) => {
         return (
-          <div className="border-[1px] border-black min-w-[500px] flex flex-col items-center gap-y-5">
-            <div>Day {planElement.dayNumber}</div>
+          <div className="border-x-[1px] border-y-[5px] rounded-lg overflow-y-scroll border-black min-w-[500px] flex flex-col items-center gap-y-5 pb-10">
+            <div className="w-[65%] mt-[35px] flex justify-start items-center">
+              Day {planElement.dayNumber}
+            </div>
             {planElement.dailyPlanItems.map((element) => {
-              console.log(element);
               return (
-                <div className="w-fit flex flex-col items-center gap-y-3">
+                <div className="w-fit h-fit flex flex-col items-center gap-y-3">
                   <p className="w-full flex justify-start">
                     {element.place.name}
                   </p>
@@ -26,7 +26,12 @@ export default function TravelPlanViewRightSection({
                     alt="This is place image"
                     className="w-[305px] h-[132px] rounded-xl object-cover"
                   />
-                  <input type="text" placeholder={element.memo} />
+                  <div className="mt-2 flex justify-center">
+                    <textarea
+                      className="w-[305px] h-[50px] rounded-xl border border-gray-300 p-2"
+                      placeholder={element.memo}
+                    ></textarea>
+                  </div>
                 </div>
               );
             })}

--- a/src/components/travel-plan/TravelPlanViewRightSection.tsx
+++ b/src/components/travel-plan/TravelPlanViewRightSection.tsx
@@ -1,19 +1,33 @@
-import { dailyPlansProps } from '@pages/TravelPlan';
+import { dailyPlansProps, travelPlanDataProp } from '@pages/TravelPlan';
+import { SetStateAction, Dispatch } from 'react';
 
 interface travelPlanViewRightSectionProps {
   dailyPlans: dailyPlansProps[];
+  handleTravelPlanData: Dispatch<SetStateAction<travelPlanDataProp | null>>;
 }
 
 export default function TravelPlanViewRightSection({
   dailyPlans,
+  handleTravelPlanData,
 }: travelPlanViewRightSectionProps) {
+  const modifyPlanState = (
+    dayIndex: number,
+    placeOrderIndex: number,
+    actionType: 'up' | 'down' | 'delete'
+  ): void => {
+    handleTravelPlanData((prevData: travelPlanDataProp | null) => {
+      return prevData;
+    });
+  };
+
   return (
     <div className="w-[65%] h-full travel-plan-scroll-box flex font-main overflow-x-auto">
-      {dailyPlans.map((planElement) => {
+      {dailyPlans.map((planElement, idx) => {
         return (
           <div
             className="border-x-[1px] border-y-[5px] rounded-lg overflow-y-scroll border-black min-w-[500px] flex flex-col items-center gap-y-5 pb-10"
             key={planElement.id}
+            onClick={() => {}}
           >
             <div className="w-[65%] mt-[35px] flex justify-start items-center">
               Day {planElement.dayNumber}

--- a/src/components/travel-plan/TravelPlanViewSection.tsx
+++ b/src/components/travel-plan/TravelPlanViewSection.tsx
@@ -1,14 +1,22 @@
 import { travelPlanDataProp } from '@pages/TravelPlan';
 import TravelPlanViewLeftSection from './TravelPlanViewLeftSection';
 import TravelPlanViewRightSection from './TravelPlanViewRightSection';
+import { SetStateAction, Dispatch } from 'react';
+
+interface hocTravelPlanDataPropSignature {
+  (prevData: travelPlanDataProp): travelPlanDataProp;
+}
 
 interface travelPlanViewSectionsProps {
   travelPlanData: travelPlanDataProp | null;
+  handleTravelPlanData: Dispatch<SetStateAction<travelPlanDataProp | null>>;
 }
 
 export default function TravelPlanViewSections({
   travelPlanData,
+  handleTravelPlanData,
 }: travelPlanViewSectionsProps) {
+  console.log(travelPlanData);
   return (
     <section className="w-full flex h-[calc(100vh-160px)]">
       <TravelPlanViewLeftSection
@@ -17,7 +25,10 @@ export default function TravelPlanViewSections({
         endDate={travelPlanData?.endDate}
       />
       {travelPlanData?.dailyPlans && (
-        <TravelPlanViewRightSection dailyPlans={travelPlanData?.dailyPlans} />
+        <TravelPlanViewRightSection
+          dailyPlans={travelPlanData?.dailyPlans}
+          handleTravelPlanData={handleTravelPlanData}
+        />
       )}
     </section>
   );

--- a/src/pages/TravelPlan.tsx
+++ b/src/pages/TravelPlan.tsx
@@ -45,6 +45,8 @@ export default function TravelPlanPage() {
       }
       const data = await response.json();
 
+      console.log(data);
+
       setTravelPlanData(data);
     }
 

--- a/src/pages/TravelPlan.tsx
+++ b/src/pages/TravelPlan.tsx
@@ -45,8 +45,6 @@ export default function TravelPlanPage() {
       }
       const data = await response.json();
 
-      console.log(data);
-
       setTravelPlanData(data);
     }
 
@@ -56,7 +54,10 @@ export default function TravelPlanPage() {
   return (
     <div className="flex flex-col h-full">
       <Header />
-      <TravelPlanViewSections travelPlanData={travelPlanData} />
+      <TravelPlanViewSections
+        travelPlanData={travelPlanData}
+        handleTravelPlanData={setTravelPlanData}
+      />
       <Footer />
     </div>
   );


### PR DESCRIPTION
일단 세부 css 조정을 마쳤는데, 일정 간 순서 조정 & 삭제 로직을 구현 중에 있습니다. 지금 어떤 로직에서 좀 오류가 있는데, 객체 깊이 때문에 그런 것 같습니다. 관련 코드 수정 또 계속 진행하겠습니다

+ 말씀해주신 지역 20개 이상 무한 스크롤로 보이는 것도 반영해놓겠습니다