### PR TITLE
Fix : main-page에서 추천 장소 목록 8개 보이도록 수정

### DIFF
--- a/src/components/Main/MainEightRegionList.tsx
+++ b/src/components/Main/MainEightRegionList.tsx
@@ -6,7 +6,6 @@ export default function MainEightRegionList() {
   const [regionList, setRegionList] = useState<MainEightRegion[]>([]);
 
   useEffect(() => {
-    // 임시 데이터를 사용하여 상태 설정
     async function getEightRegionImage() {
       const response = await fetch(
         `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/major-region`

--- a/src/components/Main/MainEightRegionListComponent.tsx
+++ b/src/components/Main/MainEightRegionListComponent.tsx
@@ -1,14 +1,52 @@
-import { MainEightRegionComponentProps } from '@_types/type';
+import { useState, useEffect } from 'react';
+import {
+  MainEightRegionComponentProps,
+  MainRecommendPlace,
+} from '@_types/type';
 import { useNavigate } from 'react-router-dom';
-// import { useDispatch } from 'react-redux';
 import { useAppDispatch } from '@context/store';
 import { changeMainArea } from '@context/slices/select-place-slice';
+
+interface RegionPlace {
+  regionId: number;
+  places: MainRecommendPlace[];
+}
 
 export default function MainEightRegionListComponent({
   regions,
 }: MainEightRegionComponentProps) {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const [regionPlaces, setRegionPlaces] = useState<RegionPlace[]>([]);
+
+  useEffect(() => {
+    async function fetchRegionPlaces(regionId: number) {
+      const response = await fetch(
+        `${
+          import.meta.env.VITE_BACKEND_DOMAIN
+        }/tour/places?majorRegionId=${regionId}&pageSize=3`
+      );
+      const result = await response.json();
+      return result.places.slice(0, 3); // 최대 3개의 장소만 가져옴
+    }
+
+    async function loadAllRegionsPlaces() {
+      const placesPromises = regions.map(async (region) => {
+        const places = await fetchRegionPlaces(region.id);
+        return { regionId: region.id, places };
+      });
+
+      const allRegionPlaces = await Promise.all(placesPromises);
+      setRegionPlaces(allRegionPlaces);
+    }
+
+    loadAllRegionsPlaces();
+  }, [regions]);
+
+  const getPopularPlaces = (regionId: number) => {
+    const regionPlace = regionPlaces.find((rp) => rp.regionId === regionId);
+    return regionPlace ? regionPlace.places : [];
+  };
 
   if (!regions || regions.length === 0) {
     return <div>No regions available.</div>;
@@ -17,26 +55,38 @@ export default function MainEightRegionListComponent({
   return (
     <div className="flex flex-col justify-center items-center py-24 bg-white">
       <div className="grid grid-cols-2 gap-10 ">
-        {regions.map((region) => (
-          <div key={region.id} className="relative w-[560px] h-[350px]">
-            <img
-              src={region.imageUrl}
-              alt={region.name}
-              className="rounded-lg hover:cursor-pointer object-cover w-full h-3/4"
-              onClick={() => {
-                navigate(`/select-place`);
-                dispatch(changeMainArea(region.id)); // 전역 상태를 변경
-              }}
-            />
-            <div className="absolute bottom-0 left-0 right-0 bg-gray-100 bg-opacity-75 text-black p-4 rounded-b-lg">
-              <p className="font-main text-xl mb-2 font-bold">{region.name}</p>
-              <p className="font-custom text-textPurple text-sm">
-                #해당 지역 인기 장소1 #해당 지역 인기 장소2 #해당 지역 인기
-                장소3
-              </p>
+        {regions.map((region) => {
+          const popularPlaces = getPopularPlaces(region.id);
+
+          return (
+            <div key={region.id} className="relative w-[560px] h-[350px]">
+              <img
+                src={region.imageUrl}
+                alt={region.name}
+                className="rounded-lg hover:cursor-pointer object-cover w-full h-3/4"
+                onClick={() => {
+                  navigate(`/select-place`);
+                  dispatch(changeMainArea(region.id));
+                }}
+              />
+              <div className="absolute bottom-0 left-0 right-0 bg-gray-100 bg-opacity-75 text-black p-4 rounded-b-lg">
+                <p className="font-main text-xl mb-2 font-bold">
+                  {region.name}
+                </p>
+                <p className="font-custom text-textPurple text-sm">
+                  {popularPlaces.length > 0
+                    ? popularPlaces.map((place, index) => (
+                        <span key={place.id}>
+                          #{place.name}
+                          {index < popularPlaces.length - 1 && ' '}
+                        </span>
+                      ))
+                    : '#No popular places found'}
+                </p>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/Main/MainRecommendedPlaceList.tsx
+++ b/src/components/Main/MainRecommendedPlaceList.tsx
@@ -9,11 +9,20 @@ export default function MainRecommendedPlaceList() {
 
   useEffect(() => {
     async function getData() {
-      const response = await fetch(
-        `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/places?size=8`
-      );
-      const result = await response.json();
-      setRecommendedPlaces(result.places);
+      try {
+        const response = await fetch(
+          `${import.meta.env.VITE_BACKEND_DOMAIN}/tour/places?size=9`
+        );
+        const result = await response.json();
+
+        // 백엔드에서 받은 데이터가 8개보다 많으면 자르기
+        const slicedPlaces = result.places.slice(0, 8);
+
+        setRecommendedPlaces(slicedPlaces);
+        console.log(slicedPlaces);
+      } catch (error) {
+        console.error('Error fetching recommended places:', error);
+      }
     }
 
     getData();


### PR DESCRIPTION
영태님께 확인해보니 /tour/places api를 수정하셔서 그런것 같다고 말씀주셔서 size=9로 바꿔서 8개의 데이터를 받아오고, result.places 배열을 slice(0, 8)을 사용하여 최대 8개의 항목만 setRecommendedPlaces로 설정했습니다. API로부터 받은 데이터가 8개 이상일 때, 앞에서부터 8개만 잘라서 보여주도록 처리했습니다. 